### PR TITLE
Add interactive frontend with real-time download progress

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -6,12 +6,71 @@
 </head>
 <body>
     <h1>Cerca contenuti</h1>
-    {% if error %}
-    <p style="color:red">{{ error }}</p>
-    {% endif %}
-    <form method="post">
+    <form id="search-form">
         <input type="text" name="query" placeholder="Titolo">
         <input type="submit" value="Cerca">
     </form>
+    <div id="results"></div>
+    <div id="preview"></div>
+    <div id="progress"></div>
+
+<script>
+const form = document.getElementById('search-form');
+const results = document.getElementById('results');
+const preview = document.getElementById('preview');
+const progress = document.getElementById('progress');
+
+form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const query = form.query.value.trim();
+    if (!query) return;
+    const res = await fetch('/api/search?query=' + encodeURIComponent(query));
+    const data = await res.json();
+    results.innerHTML = '<ul>' + Object.entries(data).map(([name, info]) => {
+        const year = info.release_date ? info.release_date.split('-')[0] : '?';
+        const slug = info.url.split('/').pop();
+        return `<li><a href="#" data-slug="${slug}">${name} (${year})</a></li>`;
+    }).join('') + '</ul>';
+    preview.innerHTML = '';
+    progress.textContent = '';
+});
+
+results.addEventListener('click', async (e) => {
+    if (e.target.tagName !== 'A') return;
+    e.preventDefault();
+    const slug = e.target.dataset.slug;
+    const res = await fetch('/api/preview/' + slug);
+    const data = await res.json();
+    if (data.type === 'movie') {
+        preview.innerHTML = `<h2>${data.name}</h2>` +
+            `<button data-id="${data.id}">Download</button>`;
+    } else {
+        preview.innerHTML = `<h2>${data.name}</h2><ul>` +
+            data.episodeList.map(ep =>
+                `<li>S${ep.season}E${ep.episode} - ${ep.name} ` +
+                `<button data-id="${data.id}" data-episode="${ep.id}">Download</button></li>`
+            ).join('') +
+            '</ul>';
+    }
+    progress.textContent = '';
+});
+
+preview.addEventListener('click', (e) => {
+    if (e.target.tagName !== 'BUTTON') return;
+    const id = e.target.dataset.id;
+    const episode = e.target.dataset.episode;
+    const url = '/api/download/' + id + (episode ? '?e=' + episode : '');
+    progress.textContent = '0%';
+    const sse = new EventSource(url);
+    sse.onmessage = (ev) => {
+        if (ev.data === 'done') {
+            progress.textContent = 'Completato';
+            sse.close();
+        } else {
+            progress.textContent = ev.data + '%';
+        }
+    };
+});
+</script>
 </body>
 </html>

--- a/utils/download_sc_video.py
+++ b/utils/download_sc_video.py
@@ -1,6 +1,6 @@
 import yt_dlp
 
-def download_sc_video(watch_url, output_path="downloads/%(title)s.%(ext)s"):
+def download_sc_video(watch_url, output_path="downloads/%(title)s.%(ext)s", progress_callback=None):
     """
     Scarica un video da StreamingCommunity usando yt-dlp con il plugin installato.
     
@@ -11,10 +11,12 @@ def download_sc_video(watch_url, output_path="downloads/%(title)s.%(ext)s"):
     ydl_opts = {
         'outtmpl': output_path,
         'format': 'best',
-        'quiet': False,
+        'quiet': True,
         'noplaylist': True,
         'merge_output_format': 'mp4',
     }
+    if progress_callback:
+        ydl_opts['progress_hooks'] = [progress_callback]
 
     with yt_dlp.YoutubeDL(ydl_opts) as ydl:
         ydl.download([watch_url])


### PR DESCRIPTION
## Summary
- extend downloader to accept progress callbacks
- add API endpoints for search, preview, and download with SSE progress stream
- rework homepage into a small SPA that loads results and preview via fetch and shows download progress without page reloads

## Testing
- `python -m py_compile app.py utils/download_sc_video.py`

------
https://chatgpt.com/codex/tasks/task_e_68658715c8d08333b6fe5a996fc40d33