### PR TITLE
Add interactive app with real-time download progress

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -6,12 +6,92 @@
 </head>
 <body>
     <h1>Cerca contenuti</h1>
-    {% if error %}
-    <p style="color:red">{{ error }}</p>
-    {% endif %}
-    <form method="post">
+    <form id="search-form">
         <input type="text" name="query" placeholder="Titolo">
         <input type="submit" value="Cerca">
     </form>
+    <div id="results"></div>
+    <div id="preview"></div>
+    <div id="download-progress"></div>
+
+    <script>
+    const DOMAIN = "{{ domain }}";
+    const form = document.getElementById('search-form');
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const data = new FormData(form);
+        const res = await fetch('/api/search', {method: 'POST', body: data});
+        const results = await res.json();
+        showResults(results);
+    });
+
+    function showResults(results) {
+        const container = document.getElementById('results');
+        container.innerHTML = '';
+        const ul = document.createElement('ul');
+        Object.entries(results).forEach(([name, info]) => {
+            const li = document.createElement('li');
+            const a = document.createElement('a');
+            a.href = '#';
+            a.textContent = `${name} (${(info.release_date || '?').split('-')[0]})`;
+            a.addEventListener('click', () => loadPreview(info.url.split('/').pop()));
+            li.appendChild(a);
+            ul.appendChild(li);
+        });
+        container.appendChild(ul);
+    }
+
+    async function loadPreview(slug) {
+        const res = await fetch('/api/preview/' + slug);
+        const data = await res.json();
+        const container = document.getElementById('preview');
+        container.innerHTML = `<h2>${data.name}</h2><p>Tipo: ${data.type}</p>`;
+        if (data.type === 'movie') {
+            const watch = document.createElement('a');
+            watch.href = `https://${DOMAIN}/it/watch/${data.id}`;
+            watch.target = '_blank';
+            watch.textContent = 'Guarda';
+            const dl = document.createElement('button');
+            dl.textContent = 'Download';
+            dl.addEventListener('click', () => startDownload(data.id));
+            container.appendChild(watch);
+            container.appendChild(document.createTextNode(' '));
+            container.appendChild(dl);
+        } else {
+            const ul = document.createElement('ul');
+            data.episodeList.forEach(ep => {
+                const li = document.createElement('li');
+                li.textContent = `S${ep.season}E${ep.episode} - ${ep.name} `;
+                const watch = document.createElement('a');
+                watch.href = `https://${DOMAIN}/it/watch/${data.id}?e=${ep.id}`;
+                watch.target = '_blank';
+                watch.textContent = 'Guarda';
+                const dl = document.createElement('button');
+                dl.textContent = 'Download';
+                dl.addEventListener('click', () => startDownload(data.id, ep.id));
+                li.appendChild(watch);
+                li.appendChild(document.createTextNode(' '));
+                li.appendChild(dl);
+                ul.appendChild(li);
+            });
+            container.appendChild(ul);
+        }
+    }
+
+    function startDownload(id, ep=null) {
+        const progressDiv = document.getElementById('download-progress');
+        progressDiv.textContent = 'Download in corso...';
+        const url = '/api/download/' + id + (ep ? ('?e=' + ep) : '');
+        const evt = new EventSource(url);
+        evt.onmessage = (ev) => {
+            if (ev.data === 'done') {
+                progressDiv.textContent = 'Download completato!';
+                evt.close();
+            } else {
+                progressDiv.textContent = 'Progresso: ' + ev.data;
+            }
+        };
+    }
+    </script>
 </body>
 </html>

--- a/utils/download_sc_video.py
+++ b/utils/download_sc_video.py
@@ -1,4 +1,7 @@
 import yt_dlp
+import threading
+import queue
+
 
 def download_sc_video(watch_url, output_path="downloads/%(title)s.%(ext)s"):
     """
@@ -18,3 +21,35 @@ def download_sc_video(watch_url, output_path="downloads/%(title)s.%(ext)s"):
 
     with yt_dlp.YoutubeDL(ydl_opts) as ydl:
         ydl.download([watch_url])
+
+
+def download_sc_video_progress(watch_url, output_path="downloads/%(title)s.%(ext)s"):
+    """Generator that yields download progress percentages."""
+    q = queue.Queue()
+
+    def hook(d):
+        if d.get('status') == 'downloading':
+            q.put(d.get('_percent_str', '0%'))
+        elif d.get('status') == 'finished':
+            q.put('done')
+
+    ydl_opts = {
+        'outtmpl': output_path,
+        'format': 'best',
+        'quiet': True,
+        'noplaylist': True,
+        'merge_output_format': 'mp4',
+        'progress_hooks': [hook],
+    }
+
+    def run():
+        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+            ydl.download([watch_url])
+
+    threading.Thread(target=run, daemon=True).start()
+
+    while True:
+        progress = q.get()
+        yield progress
+        if progress == 'done':
+            break


### PR DESCRIPTION
## Summary
- make index page dynamic with JavaScript fetch/API usage
- stream download progress via SSE endpoint
- expose new API endpoints for search, preview and download
- implement download progress generator

## Testing
- `python -m py_compile app.py utils/*.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68658715c8d08333b6fe5a996fc40d33