### PR TITLE
Fix TV episode download

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -48,10 +48,11 @@ def get_full_info(slug):
 def handle_start_download(data):
     domain = data.get("domain")
     filmid = data.get("filmid")
+    episodeid = data.get("episodeid")
     sid = request.sid
     print(f"[INFO] Avvio download per {filmid} dal dominio {domain} (SID: {sid})")
     # Avvia il download in un thread
-    socketio.start_background_task(download_with_socket, domain, filmid, socketio, sid)
+    socketio.start_background_task(download_with_socket, domain, filmid, socketio, sid, episodeid)
 
 @socketio.on("cancel_download")
 def handle_cancel_download():

--- a/backend/utils/app_functions.py
+++ b/backend/utils/app_functions.py
@@ -50,8 +50,10 @@ def get_extended_info(sc, slug):
     results = sc.load(slug)
     return results
 
-def download_with_socket(domain, filmid, socketio, sid):
+def download_with_socket(domain, filmid, socketio, sid, episodeid=None):
     url = f'https://{domain}/it/watch/{filmid}'
+    if episodeid:
+        url += f'?e={episodeid}'
     queue = Queue()
     cancel_event = threading.Event()  # 👈 nuovo event per cancellazione
 

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -131,7 +131,8 @@ async function populateDownloadSection(slug, title) {
                 btn.onclick = () => {
                     socket.emit('start_download', {
                         domain: mainUrl,
-                        filmid: ep.id
+                        filmid: filmId,
+                        episodeid: ep.id
                     });
                 };
                 body.appendChild(btn);


### PR DESCRIPTION
## Summary
- extend socket `start_download` to accept optional `episodeid`
- build episode download URLs on the backend when needed
- update UI episode buttons to send the series id and episode id

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6885e38d5c48833388b080d7462fa608