### PR TITLE
Add dynamic 'no downloads' indicator

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -105,7 +105,7 @@
     <div id="download-tab"
         class="bg-white min-w-96 h-[calc(100vh-2.5rem)] lg:h-full rounded-[2rem] lg:rounded-[3rem] py-9 px-10 shadow border border-gray-200 flex flex-col">
         <h2 class="text-2xl">Downloads</h2>
-        <span class="text-gray-800 mt-2">Nessun download in corso.</span>
+        <span id="no-download-msg" class="text-gray-800 mt-2">Nessun download in corso.</span>
         <div id="downloads-container" class="flex flex-col gap-4 overflow-y-auto mt-10"></div>
     </div>
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -59,6 +59,8 @@ window.onload = () => {
         if (item) {
             item.percentSpan.innerText = '⚠️ Già presente';
             item.bar.classList.remove('animate-pulse');
+            item.active = false;
+            updateNoDownloadsMessage();
         }
     });
 
@@ -72,6 +74,8 @@ window.onload = () => {
                 item.cancelBtn.disabled = true;
                 item.cancelBtn.classList.add('opacity-50');
             }
+            item.active = false;
+            updateNoDownloadsMessage();
         }
     });
 
@@ -85,6 +89,8 @@ window.onload = () => {
                 item.cancelBtn.disabled = true;
                 item.cancelBtn.classList.add('opacity-50');
             }
+            item.active = false;
+            updateNoDownloadsMessage();
         }
     })
 }
@@ -92,6 +98,7 @@ window.onload = () => {
 document.addEventListener('DOMContentLoaded', async () => {
     mainUrl = await fetchUrl();
     populateUrl(mainUrl);
+    updateNoDownloadsMessage();
 
     const form = document.querySelector('form');
     const downloadBtn = document.getElementById('download-btn');

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -229,7 +229,8 @@ function createDownloadItem(id, title) {
     container.appendChild(wrapper);
     container.scrollTop = container.scrollHeight;
 
-    downloads[id] = { bar, percentSpan, etaSpan, dataSpan, speedSpan, cancelBtn, loading: true };
+    downloads[id] = { bar, percentSpan, etaSpan, dataSpan, speedSpan, cancelBtn, loading: true, active: true };
+    updateNoDownloadsMessage();
 }
 
 function startSearchLoading() {
@@ -291,6 +292,16 @@ const searchResults = document.getElementById('search-results');
 const infoTab = document.getElementById('info-tab');
 const slidingContainer = document.getElementById('sliding-container');
 const downloads = {};
+
+function updateNoDownloadsMessage() {
+    const msg = document.getElementById('no-download-msg');
+    const hasActive = Object.values(downloads).some(d => d.active);
+    if (hasActive) {
+        msg.classList.add('hidden');
+    } else {
+        msg.classList.remove('hidden');
+    }
+}
 
 function homeToSearchResult() {
     slidingContainer.classList.remove('translate-y-0');


### PR DESCRIPTION
## Summary
- hide/show "Nessun download in corso" depending on active downloads
- track active downloads in UI and update on socket events

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68888c9c1dfc833394713d9bcbabdfda