### PR TITLE
Check domain reachability from frontend

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -12,6 +12,7 @@ from utils.app_functions import (
     download_with_socket,
     cancel_download,
     get_download_state,
+    check_connection,
 )
 from scuapi import API
 from utils.fixed_api import API as FixedAPI
@@ -50,6 +51,11 @@ def home():
 @app.route("/api/get-stre-domain")
 def get_main_domain():
     return jsonify(domain)
+
+@app.route("/api/check-domain/<domain_to_check>")
+def check_domain(domain_to_check):
+    reachable = check_connection(domain_to_check)
+    return jsonify({"reachable": reachable})
 
 @app.route("/api/search/<query>")
 def search_query(query):

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -21,3 +21,14 @@ async function fetchExtendedInfo(slug) {
     const data = await res.json();
     return data;
 }
+
+async function checkDomainReachable(domain) {
+    try {
+        const res = await fetch(`/api/check-domain/${domain}`);
+        const data = await res.json();
+        return data.reachable;
+    } catch (err) {
+        console.error('Errore nel controllo del dominio', err);
+        return false;
+    }
+}

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -117,6 +117,19 @@ async function searchAndShowResults(query, updateHistory = true) {
 document.addEventListener('DOMContentLoaded', async () => {
     mainUrl = await fetchUrl();
     populateUrl(mainUrl);
+    if (mainUrl) {
+        const reachable = await checkDomainReachable(mainUrl);
+        if (!reachable) {
+            const el = document.getElementById('stre-url');
+            const link = el.querySelector('a');
+            if (link) {
+                link.classList.remove('text-blue-600');
+                link.classList.add('text-red-600');
+            } else {
+                el.classList.add('text-red-600');
+            }
+        }
+    }
     updateNoDownloadsMessage();
 
     const form = document.querySelector('form');


### PR DESCRIPTION
## Summary
- add new backend endpoint to verify domain availability
- expose JS helper `checkDomainReachable`
- verify the domain on page load and color link red when unreachable

## Testing
- `python -m py_compile backend/app.py backend/utils/*.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68889ee76e608333bdd3712ef296cab5