### PR TITLE
Add .env with HOST_DOWNLOAD_DIR

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+# Inserisci il percorso desiderato dopo l'uguale
+HOST_DOWNLOAD_DIR=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.10-slim
+
+# Install system dependencies
+RUN apt-get update && \
+    apt-get install -y ffmpeg && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set work directory
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Expose port used by the Flask app
+EXPOSE 5000
+
+CMD ["python", "backend/app.py"]

--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ python backend/app.py
 
 Il server partirà sulla porta `5000`. Aprendo `http://localhost:5000` si accede all'interfaccia web.
 
+## Avvio con Docker
+
+In alternativa è possibile eseguire l'applicazione tramite Docker. Dopo aver clonato la repository basta lanciare:
+
+```bash
+docker compose up --build
+```
+
+Il servizio sarà raggiungibile su `http://localhost:5000` come nella modalità classica.
+
+Docker Compose carica automaticamente le variabili definite nel file `.env` presente nella repository.
+Imposta il valore di `HOST_DOWNLOAD_DIR` in questo file per scegliere dove salvare i file sul tuo computer.
+Se lasci la variabile vuota verrà utilizzato il percorso predefinito `./downloads`.
+
 ## Come funziona
 
 Al lancio il backend recupera automaticamente il dominio valido di StreamingCommunity ed inizializza l'API:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  app:
+    build: .
+    ports:
+      - "5000:5000"
+    volumes:
+      - ${HOST_DOWNLOAD_DIR:-./downloads}:/app/downloads


### PR DESCRIPTION
## Summary
- ship a default `.env` file containing `HOST_DOWNLOAD_DIR=` with instructions inside
- document in README how to customize the host download folder

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6888a2fe0810833399abf788e0d95277