### PR TITLE
Fix Docker run settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Il server partirà sulla porta `5000`. Aprendo `http://localhost:5000` si accede
 In alternativa è possibile eseguire l'applicazione tramite Docker. Dopo aver clonato la repository basta lanciare:
 
 ```bash
-docker compose up --build
+docker compose up --build -d
 ```
 
 Il servizio sarà raggiungibile su `http://localhost:5000` come nella modalità classica.

--- a/backend/app.py
+++ b/backend/app.py
@@ -110,4 +110,6 @@ def handle_cancel_download(data):
     emit("download_cancelled", {"status": "cancelled", "id": download_id})
 
 if __name__ == "__main__":
-    socketio.run(app, debug=True)
+    # Allow the built-in Werkzeug server when running inside Docker.
+    # Expose the server on all interfaces for external access.
+    socketio.run(app, debug=True, host="0.0.0.0", allow_unsafe_werkzeug=True)


### PR DESCRIPTION
## Summary
- allow Werkzeug server in Docker and bind to all interfaces
- run `docker compose` in detached mode

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6889102428e08333a9ff2cf7ff6e4680