### PR TITLE
Update compose for customizable port

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,4 @@
 # Inserisci il percorso desiderato dopo l'uguale
 HOST_DOWNLOAD_DIR=
+# Imposta la porta host su cui esporre l'app Docker
+HOST_PORT=

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Il servizio sarà raggiungibile su `http://localhost:5000` come nella modalità 
 Docker Compose carica automaticamente le variabili definite nel file `.env` presente nella repository.
 Imposta il valore di `HOST_DOWNLOAD_DIR` in questo file per scegliere dove salvare i file sul tuo computer.
 Se lasci la variabile vuota verrà utilizzato il percorso predefinito `./downloads`.
+Puoi inoltre personalizzare la porta esposta all'host impostando `HOST_PORT`.
+Se non definita, la porta predefinita sarà `5000`.
 
 ## Come funziona
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@ version: '3'
 services:
   app:
     build: .
+    container_name: stre-web-app
     ports:
-      - "5000:5000"
+      - "${HOST_PORT:-5000}:5000"
     volumes:
       - ${HOST_DOWNLOAD_DIR:-./downloads}:/app/downloads


### PR DESCRIPTION
## Summary
- name the docker container
- allow host port override with `HOST_PORT` env var
- document the new option in README
- clarify default host port

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `docker compose config` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b0ca06a24833392906845a2ce4b65