### PR TITLE
feat: show download indicator

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,7 +20,7 @@
     <div class="px-10 pt-9 pb-0 flex justify-between items-center lg:hidden">
         <h2>Stre Api Downloader</h2>
         <button onclick="toggleMobileMenu()" class="relative self-end">
-            <span class="absolute top-1 bg-red-500 w-2 h-2 rounded-full"></span>
+            <span id="download-indicator" class="absolute top-1 bg-red-500 w-2 h-2 rounded-full hidden"></span>
             <span class="material-symbols-rounded text-2xl text-blue-500">
                 menu
             </span>

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -300,11 +300,18 @@ const downloads = {};
 
 function updateNoDownloadsMessage() {
     const msg = document.getElementById('no-download-msg');
+    const indicator = document.getElementById('download-indicator');
     const hasActive = Object.values(downloads).some(d => d.active);
     if (hasActive) {
         msg.classList.add('hidden');
+        if (indicator) {
+            indicator.classList.remove('hidden');
+        }
     } else {
         msg.classList.remove('hidden');
+        if (indicator) {
+            indicator.classList.add('hidden');
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- toggle red indicator when downloads are active

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689207efb6e88333a3305c1cd61a8108