### PR TITLE
Add text-pretty for improved readability

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,7 +18,7 @@
 
     <!-- Menu Bar -->
     <div class="px-10 pt-9 pb-0 flex justify-between items-center lg:hidden">
-        <h2>Stre Api Downloader</h2>
+        <h2 class="text-pretty">Stre Api Downloader</h2>
         <button onclick="toggleMobileMenu()" class="relative self-end">
             <span id="download-indicator" class="absolute top-1 bg-red-500 w-2 h-2 rounded-full hidden"></span>
             <span class="material-symbols-rounded text-2xl text-blue-500">
@@ -37,7 +37,7 @@
             <!-- form di ricerca -->
             <form class="relative h-1/3 w-full flex items-center justify-center transition-all duration-700">
                 <div class="flex flex-col items-center w-96 -translate-y-32 md:-translate-y-0">
-                    <h1 class="text-4xl text-center mb-10">Cosa vuoi scaricare?</h1>
+                    <h1 class="text-4xl text-center mb-10 text-pretty">Cosa vuoi scaricare?</h1>
                     <div class="flex items-center gap-2 border-2 border-gray-200 rounded-full p-2 pl-8 w-full">
                         <input type="text" placeholder="Titolo del film / serie tv" autofocus
                             class="outline-none w-full">
@@ -48,7 +48,7 @@
                             </span>
                         </button>
                     </div>
-                    <span id="stre-url" class="mt-3 text-gray-700">Recuper url in corso...</span>
+                    <span id="stre-url" class="mt-3 text-gray-700 text-pretty">Recuper url in corso...</span>
                 </div>
             </form>
 
@@ -63,7 +63,7 @@
                                 arrow_back
                             </span>
                         </button>
-                        <span id="search-query-title" class="text-2xl">Risultati per: john wick</span>
+                        <span id="search-query-title" class="text-2xl text-pretty">Risultati per: john wick</span>
                     </div>
                     <!-- result cards container -->
                     <div class="w-full flex-1 overflow-y-auto">
@@ -83,7 +83,7 @@
                                 arrow_back
                             </span>
                         </button>
-                        <span id="download-title" class="text-2xl">Info su </span>
+                        <span id="download-title" class="text-2xl text-pretty">Info su </span>
                     </div>
                     <div class="overflow-y-auto">
                         <div class="flex flex-col gap-2">
@@ -91,9 +91,9 @@
                                 <img id="choose-cover" class="rounded-2xl lg:rounded-none">
                                 <div
                                     class="lg:text-white lg:bg-gradient-to-t from-black via-black/80 to-transparent lg:absolute bottom-0 left-0 h-2/3 w-full lg:p-10 my-4 lg:my-0 flex flex-col-reverse">
-                                    <span id="choose-genres" class="mt-2"></span>
-                                    <p id="choose-plot" class="line-clamp-3"></p>
-                                    <span id="choose-info" class="mb-2"></span>
+                                    <span id="choose-genres" class="mt-2 text-pretty"></span>
+                                    <p id="choose-plot" class="line-clamp-3 text-pretty"></p>
+                                    <span id="choose-info" class="mb-2 text-pretty"></span>
                                 </div>
                             </div>
                             <div id="choose-episodes" class="hidden">
@@ -121,8 +121,8 @@
                 close
             </span>
         </button>
-        <h2 class="text-2xl">Downloads</h2>
-        <span id="no-download-msg" class="text-gray-800 mt-2">Nessun download in corso.</span>
+        <h2 class="text-2xl text-pretty">Downloads</h2>
+        <span id="no-download-msg" class="text-gray-800 mt-2 text-pretty">Nessun download in corso.</span>
         <div id="downloads-container" class="flex flex-col gap-4 overflow-y-auto mt-10"></div>
     </div>
 

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -21,7 +21,7 @@ function populateSearchResults(results, query, mainUrl) {
     const resultsCardsContainer = document.getElementById('search-cards-container');
 
     if (!results || Object.keys(results).length === 0) {
-        resultsCardsContainer.innerHTML = "Nessun titolo corrisponde alla tua ricerca.";
+        resultsCardsContainer.innerHTML = "<p class=\"text-pretty\">Nessun titolo corrisponde alla tua ricerca.</p>";
         return;
     }
 
@@ -40,12 +40,12 @@ function populateSearchResults(results, query, mainUrl) {
                 <img src="${imgUrl}" alt="${title}" class="w-full sm:w-auto sm:h-48 aspect-video object-contain rounded-2xl mx-auto" />
                 <div class="flex flex-col justify-between flex-1">
                 <div class="flex flex-col mt-4 sm:mt-0">
-                    <span class="font-semibold text-xl line-clamp-1 mb-2 sm:mb-4" title="${title}">
+                    <span class="font-semibold text-xl line-clamp-1 mb-2 sm:mb-4 text-pretty" title="${title}">
                     ${title}
                     </span>
-                    <span>Valutazione: <span class="font-semibold">${data.score || "?"}</span></span>
-                    <span>Tipo: <span class="font-semibold">${data.type === "movie" ? "Movie" : "Serie TV"}</span></span>
-                    <span>Uscita: <span class="font-semibold">${year}</span></span>
+                    <span class="text-pretty">Valutazione: <span class="font-semibold">${data.score || "?"}</span></span>
+                    <span class="text-pretty">Tipo: <span class="font-semibold">${data.type === "movie" ? "Movie" : "Serie TV"}</span></span>
+                    <span class="text-pretty">Uscita: <span class="font-semibold">${year}</span></span>
                 </div>
                 <div class="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-3 w-full">
                     <a href="https://${mainUrl}/it/watch/${data.id}" target="_blank"
@@ -63,7 +63,7 @@ function populateSearchResults(results, query, mainUrl) {
 
 function populateSearchResultError() {
     const resultsCardsContainer = document.getElementById('search-cards-container');
-    resultsCardsContainer.innerHTML = `<p class="text-red-500">Errore nella ricerca. Riprova più tardi.</p>`;
+    resultsCardsContainer.innerHTML = `<p class="text-red-500 text-pretty">Errore nella ricerca. Riprova più tardi.</p>`;
 }
 
 async function populateDownloadSection(slug, title) {
@@ -194,7 +194,7 @@ function createDownloadItem(id, title) {
     const header = document.createElement('div');
     header.className = 'flex justify-between items-center mb-2';
     const titleSpan = document.createElement('span');
-    titleSpan.className = 'font-semibold';
+    titleSpan.className = 'font-semibold text-pretty';
     titleSpan.textContent = title;
     const cancelBtn = document.createElement('button');
     cancelBtn.className = 'bg-red-600 rounded-[0.5em] text-white px-4 py-2 font-medium';


### PR DESCRIPTION
## Summary
- enhance readability by adding `text-pretty` to headers, spans and paragraphs in the main interface
- apply `text-pretty` to dynamically generated search results, error messages and download item titles

## Testing
- `pytest`
- `cd frontend && npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68920ba642bc8333abc7bba5ce755a8c