### PR TITLE
feat: add watch button and HLS player

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -104,10 +104,15 @@
                                 <select id="season-select" class="mb-3 p-2 border rounded w-full"></select>
                                 <div id="episodes-container" class="flex gap-4 overflow-x-auto pb-2"></div>
                             </div>
-                            <button id="download-btn"
-                                class="bg-blue-500 rounded-[0.5em] text-white px-4 py-2 font-medium">
-                                Avvia Download
-                            </button>
+                            <div class="flex gap-3">
+                                <button id="watch-btn" class="bg-green-500 rounded-[0.5em] text-white px-4 py-2 font-medium hidden">
+                                    Guarda
+                                </button>
+                                <button id="download-btn"
+                                    class="bg-blue-500 rounded-[0.5em] text-white px-4 py-2 font-medium">
+                                    Avvia Download
+                                </button>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -131,9 +136,18 @@
         <span id="release-version" class="text-center text-gray-800 mt-3"></span>
     </div>
 
+    <!-- Player Modal -->
+    <div id="player-modal" class="fixed inset-0 bg-black/80 flex items-center justify-center hidden z-50">
+        <div class="relative w-full max-w-3xl">
+            <video id="video-player" class="w-full h-auto" controls></video>
+            <button id="close-player" class="absolute top-2 right-2 text-white text-2xl">&times;</button>
+        </div>
+    </div>
+
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.1/socket.io.js"
         integrity="sha512-q/dWJ3kcmjBLU4Qc47E4A9kTB4m3wuTY7vkFJDTZKjTs8jhyGQnaUrxa0Ytd0ssMZhbNua9hE+E7Qv1j+DyZwA=="
         crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
     <script src="js/api.js"></script>
     <script src="js/ui.js"></script>
     <script src="js/app.js"></script>

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -28,6 +28,12 @@ async function fetchAppVersion() {
     return data;
 }
 
+async function fetchStreamingLinks(id) {
+    const res = await fetch(`/api/get-streaming-links/${id}`);
+    const data = await res.json();
+    return data;
+}
+
 async function checkDomainReachable(domain) {
     try {
         const res = await fetch(`/api/check-domain/${domain}`);

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -135,6 +135,8 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const form = document.querySelector('form');
     const downloadBtn = document.getElementById('download-btn');
+    const watchBtn = document.getElementById('watch-btn');
+    const closePlayerBtn = document.getElementById('close-player');
 
     form.addEventListener('submit', async (e) => {
         e.preventDefault();
@@ -154,6 +156,25 @@ document.addEventListener('DOMContentLoaded', async () => {
             filmid: filmId,
             title: filmTitle
         });
+    });
+
+    watchBtn.addEventListener('click', async () => {
+        try {
+            const links = await fetchStreamingLinks(filmId);
+            const hlsLink = links.find(l => l.includes('playlist') || l.includes('.m3u8'));
+            if (hlsLink) {
+                showPlayer(hlsLink);
+            } else {
+                alert('Nessun link disponibile');
+            }
+        } catch (err) {
+            console.error('Errore nel recupero dei link', err);
+            alert('Errore nel recupero dei link');
+        }
+    });
+
+    closePlayerBtn.addEventListener('click', () => {
+        hidePlayer();
     });
 
     handleNavigationFromURL();

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -113,6 +113,7 @@ async function populateDownloadSection(slug, title) {
     document.getElementById('choose-genres').innerHTML = `Genere: ${genresString}`;
 
     const downloadBtn = document.getElementById('download-btn');
+    const watchBtn = document.getElementById('watch-btn');
 
     if (data.type == "tv") {
         const wrapper = document.getElementById('choose-episodes');
@@ -120,6 +121,7 @@ async function populateDownloadSection(slug, title) {
         const epContainer = document.getElementById('episodes-container');
         wrapper.classList.remove('hidden');
         downloadBtn.classList.add('hidden');
+        watchBtn.classList.add('hidden');
 
         let extendedData = await fetchExtendedInfo(completeSlug);
 
@@ -190,7 +192,35 @@ async function populateDownloadSection(slug, title) {
     } else {
         document.getElementById('choose-episodes').classList.add('hidden');
         downloadBtn.classList.remove('hidden');
+        watchBtn.classList.remove('hidden');
     }
+}
+
+function showPlayer(src) {
+    const modal = document.getElementById('player-modal');
+    const video = document.getElementById('video-player');
+    modal.classList.remove('hidden');
+
+    if (Hls.isSupported()) {
+        const hls = new Hls();
+        hls.loadSource(src);
+        hls.attachMedia(video);
+        video.hlsInstance = hls;
+    } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
+        video.src = src;
+    }
+}
+
+function hidePlayer() {
+    const modal = document.getElementById('player-modal');
+    const video = document.getElementById('video-player');
+    modal.classList.add('hidden');
+    if (video.hlsInstance) {
+        video.hlsInstance.destroy();
+        video.hlsInstance = null;
+    }
+    video.pause();
+    video.removeAttribute('src');
 }
 
 function updateDownloadProgress(id, percent, eta = null, downloaded = null, total = null, speed = null) {


### PR DESCRIPTION
## Summary
- add HLS-based player and watch button for movie pages
- expose API helper to retrieve streaming links
- wire up streaming player and close button

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68948bdaeac083339d2e1d9990d115d5