### PR TITLE
feat: add watch button and HLS player

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -144,7 +144,7 @@
             <input id="player-progress" type="range" min="0" value="0" class="flex-1">
             <button id="fullscreen-btn" class="text-white material-symbols-rounded text-3xl">fullscreen</button>
         </div>
-        <button id="close-player" class="absolute top-2 right-2 text-white material-symbols-rounded text-3xl">close</button>
+        <button id="close-player" class="absolute top-2 right-2 text-white material-symbols-rounded text-3xl transition-opacity duration-300">close</button>
     </div>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.1/socket.io.js"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -104,10 +104,15 @@
                                 <select id="season-select" class="mb-3 p-2 border rounded w-full"></select>
                                 <div id="episodes-container" class="flex gap-4 overflow-x-auto pb-2"></div>
                             </div>
-                            <button id="download-btn"
-                                class="bg-blue-500 rounded-[0.5em] text-white px-4 py-2 font-medium">
-                                Avvia Download
-                            </button>
+                            <div class="flex gap-3">
+                                <button id="watch-btn" class="bg-green-500 rounded-[0.5em] text-white px-4 py-2 font-medium hidden">
+                                    Guarda
+                                </button>
+                                <button id="download-btn"
+                                    class="bg-blue-500 rounded-[0.5em] text-white px-4 py-2 font-medium">
+                                    Avvia Download
+                                </button>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -131,11 +136,24 @@
         <span id="release-version" class="text-center text-gray-800 mt-3"></span>
     </div>
 
+    <!-- Player Modal -->
+    <div id="player-modal" class="fixed inset-0 bg-black hidden z-50">
+        <video id="video-player" class="w-full h-full object-contain"></video>
+        <div id="player-controls" class="absolute bottom-0 left-0 right-0 flex items-center gap-4 p-4 bg-black/60">
+            <button id="play-pause" class="text-white">Play</button>
+            <input id="player-progress" type="range" min="0" value="0" class="flex-1">
+            <button id="fullscreen-btn" class="text-white">Fullscreen</button>
+        </div>
+        <button id="close-player" class="absolute top-2 right-2 text-white text-2xl">&times;</button>
+    </div>
+
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.1/socket.io.js"
         integrity="sha512-q/dWJ3kcmjBLU4Qc47E4A9kTB4m3wuTY7vkFJDTZKjTs8jhyGQnaUrxa0Ytd0ssMZhbNua9hE+E7Qv1j+DyZwA=="
         crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
     <script src="js/api.js"></script>
     <script src="js/ui.js"></script>
+    <script src="js/player.js"></script>
     <script src="js/app.js"></script>
 </body>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -138,6 +138,48 @@
 
     <!-- Player Modal -->
         <div id="player-modal" class="fixed inset-0 bg-black hidden z-50">
+        <div id="player-loading" class="absolute inset-0 flex items-center justify-center hidden">
+            <svg width="20" height="20" stroke="#ffff" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <style>
+                    .spinner_V8m1 {
+                        transform-origin: center;
+                        animation: spinner_zKoa 2s linear infinite
+                    }
+
+                    .spinner_V8m1 circle {
+                        stroke-linecap: round;
+                        animation: spinner_YpZS 1.5s ease-in-out infinite
+                    }
+
+                    @keyframes spinner_zKoa {
+                        100% {
+                            transform: rotate(360deg)
+                        }
+                    }
+
+                    @keyframes spinner_YpZS {
+                        0% {
+                            stroke-dasharray: 0 150;
+                            stroke-dashoffset: 0
+                        }
+
+                        47.5% {
+                            stroke-dasharray: 42 150;
+                            stroke-dashoffset: -16
+                        }
+
+                        95%,
+                        100% {
+                            stroke-dasharray: 42 150;
+                            stroke-dashoffset: -59
+                        }
+                    }
+                </style>
+                <g class="spinner_V8m1">
+                    <circle cx="12" cy="12" r="9.5" fill="none" stroke-width="3"></circle>
+                </g>
+            </svg>
+        </div>
         <video id="video-player" class="w-full h-full object-contain"></video>
         <div id="player-controls" class="absolute bottom-0 left-0 right-0 flex items-center gap-4 p-4 bg-black/60 transition-opacity duration-300">
             <button id="play-pause" class="text-white material-symbols-rounded text-3xl">play_arrow</button>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -139,7 +139,7 @@
     <!-- Player Modal -->
         <div id="player-modal" class="fixed inset-0 bg-black hidden z-50">
         <video id="video-player" class="w-full h-full object-contain"></video>
-        <div id="player-controls" class="absolute bottom-0 left-0 right-0 flex items-center gap-4 p-4 bg-black/60">
+        <div id="player-controls" class="absolute bottom-0 left-0 right-0 flex items-center gap-4 p-4 bg-black/60 transition-opacity duration-300">
             <button id="play-pause" class="text-white material-symbols-rounded text-3xl">play_arrow</button>
             <input id="player-progress" type="range" min="0" value="0" class="flex-1">
             <button id="fullscreen-btn" class="text-white material-symbols-rounded text-3xl">fullscreen</button>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -137,14 +137,14 @@
     </div>
 
     <!-- Player Modal -->
-    <div id="player-modal" class="fixed inset-0 bg-black hidden z-50">
+        <div id="player-modal" class="fixed inset-0 bg-black hidden z-50">
         <video id="video-player" class="w-full h-full object-contain"></video>
         <div id="player-controls" class="absolute bottom-0 left-0 right-0 flex items-center gap-4 p-4 bg-black/60">
-            <button id="play-pause" class="text-white">Play</button>
+            <button id="play-pause" class="text-white material-symbols-rounded text-3xl">play_arrow</button>
             <input id="player-progress" type="range" min="0" value="0" class="flex-1">
-            <button id="fullscreen-btn" class="text-white">Fullscreen</button>
+            <button id="fullscreen-btn" class="text-white material-symbols-rounded text-3xl">fullscreen</button>
         </div>
-        <button id="close-player" class="absolute top-2 right-2 text-white text-2xl">&times;</button>
+        <button id="close-player" class="absolute top-2 right-2 text-white material-symbols-rounded text-3xl">close</button>
     </div>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.1/socket.io.js"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -142,6 +142,7 @@
         <div id="player-controls" class="absolute bottom-0 left-0 right-0 flex items-center gap-4 p-4 bg-black/60 transition-opacity duration-300">
             <button id="play-pause" class="text-white material-symbols-rounded text-3xl">play_arrow</button>
             <input id="player-progress" type="range" min="0" value="0" class="flex-1">
+            <span id="time-display" class="text-white text-sm w-20 text-center">0:00/0:00</span>
             <button id="fullscreen-btn" class="text-white material-symbols-rounded text-3xl">fullscreen</button>
         </div>
         <button id="close-player" class="absolute top-2 right-2 text-white material-symbols-rounded text-3xl transition-opacity duration-300">close</button>

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -28,6 +28,12 @@ async function fetchAppVersion() {
     return data;
 }
 
+async function fetchStreamingLinks(id) {
+    const res = await fetch(`/api/get-streaming-links/${id}`);
+    const data = await res.json();
+    return data;
+}
+
 async function checkDomainReachable(domain) {
     try {
         const res = await fetch(`/api/check-domain/${domain}`);

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -135,6 +135,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const form = document.querySelector('form');
     const downloadBtn = document.getElementById('download-btn');
+    const watchBtn = document.getElementById('watch-btn');
 
     form.addEventListener('submit', async (e) => {
         e.preventDefault();
@@ -154,6 +155,21 @@ document.addEventListener('DOMContentLoaded', async () => {
             filmid: filmId,
             title: filmTitle
         });
+    });
+
+    watchBtn.addEventListener('click', async () => {
+        try {
+            const links = await fetchStreamingLinks(filmId);
+            const hlsLink = links.find(l => l.includes('playlist') || l.includes('.m3u8'));
+            if (hlsLink) {
+                showPlayer(hlsLink);
+            } else {
+                alert('Nessun link disponibile');
+            }
+        } catch (err) {
+            console.error('Errore nel recupero dei link', err);
+            alert('Errore nel recupero dei link');
+        }
     });
 
     handleNavigationFromURL();

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -162,7 +162,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             const links = await fetchStreamingLinks(filmId);
             const hlsLink = links.find(l => l.includes('playlist') || l.includes('.m3u8'));
             if (hlsLink) {
-                showPlayer(hlsLink);
+                showPlayer(hlsLink, filmId);
             } else {
                 alert('Nessun link disponibile');
             }

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -4,6 +4,7 @@ let mainUrl = null;
 let filmId = null;
 let filmTitle = null;
 let lastSearchQuery = null;
+const playerModal = document.getElementById('player-modal');
 
 window.onload = () => {
     socket = io();
@@ -206,5 +207,9 @@ async function handleNavigationFromURL() {
 }
 
 window.addEventListener('popstate', () => {
-    handleNavigationFromURL();
+    if (!playerModal.classList.contains('hidden')) {
+        hidePlayer();
+    } else {
+        handleNavigationFromURL();
+    }
 });

--- a/frontend/js/player.js
+++ b/frontend/js/player.js
@@ -12,10 +12,12 @@
 
     function hideControls() {
         controls.classList.add('opacity-0', 'pointer-events-none');
+        closeBtn.classList.add('opacity-0', 'pointer-events-none');
     }
 
     function showControls() {
         controls.classList.remove('opacity-0', 'pointer-events-none');
+        closeBtn.classList.remove('opacity-0', 'pointer-events-none');
         if (!isTouch || video.paused) return;
         clearTimeout(hideControlsTimeout);
         hideControlsTimeout = setTimeout(hideControls, 3000);
@@ -99,6 +101,14 @@
     fullscreenBtn.addEventListener('click', toggleFullscreen);
     closeBtn.addEventListener('click', hidePlayer);
 
+    modal.addEventListener('click', (e) => {
+        if (isTouch) return;
+        if (e.target === modal || e.target === video) {
+            togglePlay();
+            updatePlayButton();
+        }
+    });
+
     video.addEventListener('play', () => {
         updatePlayButton();
         showControls();
@@ -144,6 +154,7 @@
     if (isTouch) {
         video.addEventListener('touchstart', showControls);
         controls.addEventListener('touchstart', showControls);
+        modal.addEventListener('touchstart', showControls);
     }
 
     document.addEventListener('keydown', (e) => {

--- a/frontend/js/player.js
+++ b/frontend/js/player.js
@@ -37,6 +37,7 @@
 
     function showPlayer(src, filmId) {
         modal.classList.remove('hidden');
+        history.pushState({ ...(history.state || {}), player: true }, '', location.href);
         currentFilmId = filmId;
         resumeTime = parseFloat(localStorage.getItem('progress-' + filmId)) || 0;
         showLoading();
@@ -64,7 +65,7 @@
         showControls();
     }
 
-    function hidePlayer() {
+    function hidePlayer(popState = false) {
         modal.classList.add('hidden');
         if (document.fullscreenElement) {
             document.exitFullscreen();
@@ -85,6 +86,9 @@
         currentFilmId = null;
         resumeTime = 0;
         hideLoading();
+        if (popState && history.state && history.state.player) {
+            history.back();
+        }
     }
 
     function togglePlay() {
@@ -137,7 +141,7 @@
     });
 
     fullscreenBtn.addEventListener('click', toggleFullscreen);
-    closeBtn.addEventListener('click', hidePlayer);
+    closeBtn.addEventListener('click', () => hidePlayer(true));
 
     modal.addEventListener('click', (e) => {
         if (isTouch) return;
@@ -222,7 +226,7 @@
                 toggleFullscreen();
                 break;
             case 'Escape':
-                hidePlayer();
+                hidePlayer(true);
                 break;
         }
     });

--- a/frontend/js/player.js
+++ b/frontend/js/player.js
@@ -87,6 +87,25 @@
 
     document.addEventListener('fullscreenchange', updateFullscreenButton);
 
+    // Enable double-tap seeking on touch devices only
+    if ('ontouchstart' in window || navigator.maxTouchPoints > 0) {
+        let lastTap = 0;
+        video.addEventListener('touchend', (e) => {
+            const currentTime = Date.now();
+            if (currentTime - lastTap < 300) {
+                const tapX = e.changedTouches[0].clientX;
+                const half = window.innerWidth / 2;
+                if (tapX < half) {
+                    video.currentTime = Math.max(video.currentTime - 10, 0);
+                } else {
+                    video.currentTime = Math.min(video.currentTime + 10, video.duration);
+                }
+                updateProgress();
+            }
+            lastTap = currentTime;
+        });
+    }
+
     document.addEventListener('keydown', (e) => {
         if (modal.classList.contains('hidden')) return;
         switch (e.key) {

--- a/frontend/js/player.js
+++ b/frontend/js/player.js
@@ -47,7 +47,11 @@
     }
 
     function updatePlayButton() {
-        playPauseBtn.textContent = video.paused ? 'Play' : 'Pause';
+        playPauseBtn.textContent = video.paused ? 'play_arrow' : 'pause';
+    }
+
+    function updateFullscreenButton() {
+        fullscreenBtn.textContent = document.fullscreenElement ? 'fullscreen_exit' : 'fullscreen';
     }
 
     function updateProgress() {
@@ -80,6 +84,8 @@
     video.addEventListener('timeupdate', updateProgress);
     video.addEventListener('loadedmetadata', updateProgress);
     progressBar.addEventListener('input', seekVideo);
+
+    document.addEventListener('fullscreenchange', updateFullscreenButton);
 
     document.addEventListener('keydown', (e) => {
         if (modal.classList.contains('hidden')) return;

--- a/frontend/js/player.js
+++ b/frontend/js/player.js
@@ -7,6 +7,7 @@
     const closeBtn = document.getElementById('close-player');
     const controls = document.getElementById('player-controls');
     const timeDisplay = document.getElementById('time-display');
+    const loading = document.getElementById('player-loading');
     const isTouch = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
     let hideControlsTimeout = null;
     let hlsInstance = null;
@@ -26,10 +27,19 @@
         hideControlsTimeout = setTimeout(hideControls, 3000);
     }
 
+    function showLoading() {
+        loading.classList.remove('hidden');
+    }
+
+    function hideLoading() {
+        loading.classList.add('hidden');
+    }
+
     function showPlayer(src, filmId) {
         modal.classList.remove('hidden');
         currentFilmId = filmId;
         resumeTime = parseFloat(localStorage.getItem('progress-' + filmId)) || 0;
+        showLoading();
 
         if (Hls.isSupported()) {
             hlsInstance = new Hls();
@@ -74,6 +84,7 @@
         timeDisplay.textContent = '0:00/0:00';
         currentFilmId = null;
         resumeTime = 0;
+        hideLoading();
     }
 
     function togglePlay() {
@@ -146,6 +157,9 @@
     });
     video.addEventListener('timeupdate', updateProgress);
     video.addEventListener('loadedmetadata', updateProgress);
+    video.addEventListener('loadeddata', hideLoading);
+    video.addEventListener('waiting', showLoading);
+    video.addEventListener('playing', hideLoading);
     video.addEventListener('ended', () => {
         if (currentFilmId) {
             localStorage.removeItem('progress-' + currentFilmId);

--- a/frontend/js/player.js
+++ b/frontend/js/player.js
@@ -1,0 +1,110 @@
+(function () {
+    const modal = document.getElementById('player-modal');
+    const video = document.getElementById('video-player');
+    const playPauseBtn = document.getElementById('play-pause');
+    const progressBar = document.getElementById('player-progress');
+    const fullscreenBtn = document.getElementById('fullscreen-btn');
+    const closeBtn = document.getElementById('close-player');
+    let hlsInstance = null;
+
+    function showPlayer(src) {
+        modal.classList.remove('hidden');
+
+        if (Hls.isSupported()) {
+            hlsInstance = new Hls();
+            hlsInstance.loadSource(src);
+            hlsInstance.attachMedia(video);
+        } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
+            video.src = src;
+        }
+
+        video.play();
+        if (modal.requestFullscreen) {
+            modal.requestFullscreen();
+        }
+    }
+
+    function hidePlayer() {
+        modal.classList.add('hidden');
+        if (document.fullscreenElement) {
+            document.exitFullscreen();
+        }
+        if (hlsInstance) {
+            hlsInstance.destroy();
+            hlsInstance = null;
+        }
+        video.pause();
+        video.removeAttribute('src');
+        progressBar.value = 0;
+    }
+
+    function togglePlay() {
+        if (video.paused) {
+            video.play();
+        } else {
+            video.pause();
+        }
+    }
+
+    function updatePlayButton() {
+        playPauseBtn.textContent = video.paused ? 'Play' : 'Pause';
+    }
+
+    function updateProgress() {
+        progressBar.max = video.duration || 0;
+        progressBar.value = video.currentTime;
+    }
+
+    function seekVideo() {
+        video.currentTime = progressBar.value;
+    }
+
+    function toggleFullscreen() {
+        if (document.fullscreenElement) {
+            document.exitFullscreen();
+        } else if (modal.requestFullscreen) {
+            modal.requestFullscreen();
+        }
+    }
+
+    playPauseBtn.addEventListener('click', () => {
+        togglePlay();
+        updatePlayButton();
+    });
+
+    fullscreenBtn.addEventListener('click', toggleFullscreen);
+    closeBtn.addEventListener('click', hidePlayer);
+
+    video.addEventListener('play', updatePlayButton);
+    video.addEventListener('pause', updatePlayButton);
+    video.addEventListener('timeupdate', updateProgress);
+    video.addEventListener('loadedmetadata', updateProgress);
+    progressBar.addEventListener('input', seekVideo);
+
+    document.addEventListener('keydown', (e) => {
+        if (modal.classList.contains('hidden')) return;
+        switch (e.key) {
+            case ' ':
+            case 'k':
+                e.preventDefault();
+                togglePlay();
+                updatePlayButton();
+                break;
+            case 'ArrowRight':
+                video.currentTime = Math.min(video.currentTime + 5, video.duration);
+                break;
+            case 'ArrowLeft':
+                video.currentTime = Math.max(video.currentTime - 5, 0);
+                break;
+            case 'f':
+                toggleFullscreen();
+                break;
+            case 'Escape':
+                hidePlayer();
+                break;
+        }
+    });
+
+    window.showPlayer = showPlayer;
+    window.hidePlayer = hidePlayer;
+})();

--- a/frontend/js/player.js
+++ b/frontend/js/player.js
@@ -63,6 +63,7 @@
             modal.requestFullscreen();
         }
         showControls();
+        updateWatchButtonLabel();
     }
 
     function hidePlayer(popState = false) {
@@ -83,6 +84,7 @@
         video.removeAttribute('src');
         progressBar.value = 0;
         timeDisplay.textContent = '0:00/0:00';
+        updateWatchButtonLabel();
         currentFilmId = null;
         resumeTime = 0;
         hideLoading();
@@ -120,6 +122,7 @@
         timeDisplay.textContent = `${formatTime(video.currentTime)} / ${formatTime(video.duration)}`;
         if (currentFilmId) {
             localStorage.setItem('progress-' + currentFilmId, video.currentTime);
+            updateWatchButtonLabel();
         }
     }
 
@@ -167,6 +170,7 @@
     video.addEventListener('ended', () => {
         if (currentFilmId) {
             localStorage.removeItem('progress-' + currentFilmId);
+            updateWatchButtonLabel();
         }
     });
     progressBar.addEventListener('input', seekVideo);
@@ -233,4 +237,12 @@
 
     window.showPlayer = showPlayer;
     window.hidePlayer = hidePlayer;
+    window.updateWatchButtonLabel = updateWatchButtonLabel;
+
+    function updateWatchButtonLabel(id = currentFilmId || window.filmId) {
+        const watchBtn = document.getElementById('watch-btn');
+        if (!watchBtn || !id) return;
+        const progress = parseFloat(localStorage.getItem('progress-' + id) || '0');
+        watchBtn.textContent = progress > 0 ? 'Riprendi' : 'Guarda';
+    }
 })();

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -193,6 +193,7 @@ async function populateDownloadSection(slug, title) {
         document.getElementById('choose-episodes').classList.add('hidden');
         downloadBtn.classList.remove('hidden');
         watchBtn.classList.remove('hidden');
+        updateWatchButtonLabel(filmId);
     }
 }
 

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -113,6 +113,7 @@ async function populateDownloadSection(slug, title) {
     document.getElementById('choose-genres').innerHTML = `Genere: ${genresString}`;
 
     const downloadBtn = document.getElementById('download-btn');
+    const watchBtn = document.getElementById('watch-btn');
 
     if (data.type == "tv") {
         const wrapper = document.getElementById('choose-episodes');
@@ -120,6 +121,7 @@ async function populateDownloadSection(slug, title) {
         const epContainer = document.getElementById('episodes-container');
         wrapper.classList.remove('hidden');
         downloadBtn.classList.add('hidden');
+        watchBtn.classList.add('hidden');
 
         let extendedData = await fetchExtendedInfo(completeSlug);
 
@@ -190,9 +192,8 @@ async function populateDownloadSection(slug, title) {
     } else {
         document.getElementById('choose-episodes').classList.add('hidden');
         downloadBtn.classList.remove('hidden');
+        watchBtn.classList.remove('hidden');
     }
-}
-
 function updateDownloadProgress(id, percent, eta = null, downloaded = null, total = null, speed = null) {
     const item = downloads[id];
     if (!item) return;

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -194,6 +194,8 @@ async function populateDownloadSection(slug, title) {
         downloadBtn.classList.remove('hidden');
         watchBtn.classList.remove('hidden');
     }
+}
+
 function updateDownloadProgress(id, percent, eta = null, downloaded = null, total = null, speed = null) {
     const item = downloads[id];
     if (!item) return;


### PR DESCRIPTION
## Summary
- add HLS-based player and watch button for movie pages
- expose API helper to retrieve streaming links
- wire up streaming player and close button
- implement custom fullscreen video player with keyboard controls

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68948bdaeac083339d2e1d9990d115d5