### PR TITLE
Replace watch link with streaming button in search results

### DIFF
--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -78,8 +78,8 @@ function populateSearchResults(results, query, mainUrl) {
                     <span class="text-pretty">Uscita: <span class="font-semibold">${year}</span></span>
                 </div>
                 <div class="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-3 w-full">
-                    <a href="https://${mainUrl}/it/watch/${data.id}" target="_blank"
-                    class="bg-gray-200 rounded-[0.5em] text-gray-800 px-4 py-2 font-medium text-center">Guarda</a>
+                    <button onClick="watchFromSearch(${data.id})"
+                    class="bg-green-500 rounded-[0.5em] text-white px-4 py-2 font-medium">Guarda</button>
                     <button onClick="searchResultToDownload(${data.id}, '${data.slug}', '${title}')"
                     class="bg-blue-500 rounded-[0.5em] text-white px-4 py-2 font-medium">Info</button>
                 </div>
@@ -94,6 +94,21 @@ function populateSearchResults(results, query, mainUrl) {
 function populateSearchResultError() {
     const resultsCardsContainer = document.getElementById('search-cards-container');
     resultsCardsContainer.innerHTML = `<p class="text-red-500 text-pretty">Errore nella ricerca. Riprova più tardi.</p>`;
+}
+
+async function watchFromSearch(id) {
+    try {
+        const links = await fetchStreamingLinks(id);
+        const hlsLink = links.find(l => l.includes('playlist') || l.includes('.m3u8'));
+        if (hlsLink) {
+            showPlayer(hlsLink, id);
+        } else {
+            alert('Nessun link disponibile');
+        }
+    } catch (err) {
+        console.error('Errore nel recupero dei link', err);
+        alert('Errore nel recupero dei link');
+    }
 }
 
 async function populateDownloadSection(slug, title) {


### PR DESCRIPTION
## Summary
- Replace external watch link with in-app watch button
- Add handler to fetch streaming link and play video directly from search results

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894c53b2284833391c2645f3167879d