### PR TITLE
Add watch button for TV series episodes

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -99,9 +99,10 @@ def get_full_info(slug):
     results = get_extended_info(stre.fixed_sc, slug)
     return jsonify(results)
 
-@app.route("/api/get-streaming-links/<id>")
-def get_streaming_links(id):
-    results = get_links(stre.fixed_sc, id)
+@app.route("/api/get-streaming-links/<content_id>")
+def get_streaming_links(content_id):
+    episode_id = request.args.get("episode_id")
+    results = get_links(stre.fixed_sc, content_id, episode_id)
     return jsonify(results)
 
 @socketio.on("start_download")

--- a/backend/utils/app_functions.py
+++ b/backend/utils/app_functions.py
@@ -79,8 +79,8 @@ def get_extended_info(sc, slug):
     results = sc.load(slug)
     return results
 
-def get_links(sc, id):
-    results = sc.get_links(id)
+def get_links(sc, content_id, episode_id=None):
+    results = sc.get_links(content_id, episode_id)
     return results
 
 VERSION_FILE = ".version"

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -28,8 +28,11 @@ async function fetchAppVersion() {
     return data;
 }
 
-async function fetchStreamingLinks(id) {
-    const res = await fetch(`/api/get-streaming-links/${id}`);
+async function fetchStreamingLinks(id, episodeId = null) {
+    const url = episodeId
+        ? `/api/get-streaming-links/${id}?episode_id=${episodeId}`
+        : `/api/get-streaming-links/${id}`;
+    const res = await fetch(url);
     const data = await res.json();
     return data;
 }

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -180,10 +180,29 @@ async function populateDownloadSection(slug, title) {
                 desc.className = 'text-xs line-clamp-3';
                 desc.textContent = ep.description || '';
                 body.appendChild(desc);
-                const btn = document.createElement('button');
-                btn.className = 'bg-blue-500 text-white rounded px-2 py-1 text-xs mt-auto';
-                btn.textContent = 'Scarica';
-                btn.onclick = () => {
+                const btnContainer = document.createElement('div');
+                btnContainer.className = 'flex gap-2 mt-auto';
+                const watchEpBtn = document.createElement('button');
+                watchEpBtn.className = 'bg-gray-200 text-gray-800 rounded px-2 py-1 text-xs';
+                watchEpBtn.textContent = 'Guarda';
+                watchEpBtn.onclick = async () => {
+                    try {
+                        const links = await fetchStreamingLinks(filmId, ep.id);
+                        const hlsLink = links.find(l => l.includes('playlist') || l.includes('.m3u8'));
+                        if (hlsLink) {
+                            showPlayer(hlsLink, ep.id);
+                        } else {
+                            alert('Nessun link disponibile');
+                        }
+                    } catch (err) {
+                        console.error('Errore nel recupero dei link', err);
+                        alert('Errore nel recupero dei link');
+                    }
+                };
+                const downloadEpBtn = document.createElement('button');
+                downloadEpBtn.className = 'bg-blue-500 text-white rounded px-2 py-1 text-xs';
+                downloadEpBtn.textContent = 'Scarica';
+                downloadEpBtn.onclick = () => {
                     socket.emit('start_download', {
                         domain: mainUrl,
                         filmid: filmId,
@@ -194,7 +213,9 @@ async function populateDownloadSection(slug, title) {
                         episode: ep.episode
                     });
                 };
-                body.appendChild(btn);
+                btnContainer.appendChild(watchEpBtn);
+                btnContainer.appendChild(downloadEpBtn);
+                body.appendChild(btnContainer);
 
                 card.appendChild(body);
                 epContainer.appendChild(card);


### PR DESCRIPTION
## Summary
- allow backend and client API to accept optional episode IDs for streaming links
- add watch controls for individual TV episodes in the UI

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894d5e10b788333a931f0f98543704d