### PR TITLE
feat: avoid duplicate downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,11 @@ socket.on('download_progress', data => {
 socket.on('download_exists', data => {
     alert(`${data.title} è già stato scaricato.`);
 });
+
+// se il contenuto è già in download, viene notificato
+socket.on('download_in_progress', data => {
+    alert(`${data.title} è già in download.`);
+});
 ```
 
 ## Download multipli e gestione multiutente
@@ -164,6 +169,5 @@ sessioni.
 
 - gestione download interrotto dal server
 - implementare cronologia (es. download completati, interrotti, ecc..)
-- check download già in corso
 - aggiungere possibilità di usare custom url
 - rilevamento nuova versione

--- a/backend/utils/app_functions.py
+++ b/backend/utils/app_functions.py
@@ -152,6 +152,20 @@ def download_with_socket(
         display_title = title
 
     final_path = output_path.replace('%(ext)s', 'mp4')
+    # Se è già in corso un download per lo stesso file, evita di avviarne un altro
+    for existing_id, state in download_states.items():
+        if state.get('path') == final_path:
+            socketio.emit(
+                'download_in_progress',
+                {
+                    'status': 'in_progress',
+                    'id': existing_id,
+                    'title': state.get('title') or display_title,
+                },
+            )
+            print('[INFO] Download non avviato: download già in corso.')
+            return
+
     if os.path.exists(final_path):
         socketio.emit(
             'download_exists',
@@ -177,6 +191,7 @@ def download_with_socket(
         "downloading": True,
         "progress": None,
         "title": display_title,
+        "path": final_path,
     }
 
     if display_title:

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -66,6 +66,20 @@ window.onload = () => {
         }
     });
 
+    socket.on('download_in_progress', data => {
+        let item = downloads[data.id];
+        if (!item && data.title) {
+            createDownloadItem(data.id, data.title);
+            item = downloads[data.id];
+        }
+        if (item) {
+            item.percentSpan.innerText = '⚠️ Già in corso';
+            item.bar.classList.add('animate-pulse');
+            item.active = true;
+            updateNoDownloadsMessage();
+        }
+    });
+
     // Gestione dell'annullamento del download
     socket.on("download_cancelled", data => {
         updateDownloadProgress(data.id, 0);


### PR DESCRIPTION
## Summary
- prevent starting a download for content already downloading
- surface in-progress downloads to clients via new `download_in_progress` event
- document and handle duplicate download notifications on the frontend

## Testing
- `python -m py_compile backend/utils/app_functions.py`
- `node --check frontend/js/app.js`
- `node --check frontend/js/ui.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894df1059808333945910dafa0c7060