### PR TITLE
Show player controls on desktop mouse move

### DIFF
--- a/frontend/js/player.js
+++ b/frontend/js/player.js
@@ -22,8 +22,8 @@
     function showControls() {
         controls.classList.remove('opacity-0', 'pointer-events-none');
         closeBtn.classList.remove('opacity-0', 'pointer-events-none');
-        if (!isTouch || video.paused) return;
         clearTimeout(hideControlsTimeout);
+        if (video.paused) return;
         hideControlsTimeout = setTimeout(hideControls, 3000);
     }
 
@@ -209,6 +209,8 @@
         video.addEventListener('touchstart', showControls);
         controls.addEventListener('touchstart', showControls);
         modal.addEventListener('touchstart', showControls);
+    } else {
+        modal.addEventListener('mousemove', showControls);
     }
 
     document.addEventListener('keydown', (e) => {


### PR DESCRIPTION
## Summary
- show video controls on mouse movement for desktop
- hide controls after inactivity when video is playing

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894e1a759288333808278f79c8fa6ca