### PR TITLE
Gestione dei download interrotti dal server

### DIFF
--- a/backend/utils/app_functions.py
+++ b/backend/utils/app_functions.py
@@ -239,6 +239,19 @@ def download_with_socket(
                     download_states.pop(download_id, None)
                     cancel_flags.pop(download_id, None)
                     break
+                elif d['status'] == 'error':
+                    socketio.emit(
+                        'download_error',
+                        {
+                            'status': 'error',
+                            'id': download_id,
+                            'message': d.get('message'),
+                        },
+                    )
+                    download_states.pop(download_id, None)
+                    cancel_flags.pop(download_id, None)
+                    print(f"[ERROR] Download interrotto: {download_id}")
+                    break
 
             except Empty:
                 time.sleep(0.1)

--- a/backend/utils/download_sc_video.py
+++ b/backend/utils/download_sc_video.py
@@ -36,4 +36,4 @@ def download_sc_video(url, queue, cancel_event: threading.Event, output_path="do
             ydl.download([url])
         except Exception as e:
             print(f"[YT-DLP] Download interrotto: {e}")
-            queue.put({'status': 'cancelled'})  # 👈 utile per inviare info al socket
+            queue.put({'status': 'error', 'message': str(e)})  # 👈 utile per inviare info al socket

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -95,6 +95,24 @@ window.onload = () => {
         }
     });
 
+    // Gestione di un download interrotto o fallito
+    socket.on("download_error", data => {
+        updateDownloadProgress(data.id, 0);
+        const item = downloads[data.id];
+        if (item) {
+            item.percentSpan.innerText = "⚠️ Errore";
+            if (item.cancelBtn) {
+                item.cancelBtn.disabled = true;
+                item.cancelBtn.classList.add('opacity-50');
+            }
+            item.active = false;
+            updateNoDownloadsMessage();
+        }
+        if (data.message) {
+            console.error("Download error:", data.message);
+        }
+    });
+
     // Gestione download completato
     socket.on("download_finished", data => {
         updateDownloadProgress(data.id, 0);


### PR DESCRIPTION
## Summary
- Propagate server-side download errors via the queue
- Emit and handle a new `download_error` socket event
- Update frontend to display interrupted downloads as errors

## Testing
- `python -m py_compile backend/utils/download_sc_video.py backend/utils/app_functions.py`
- `node --check frontend/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_6894e44200c883339be1bfea79a47e45