### PR TITLE
Implement user sign-up flow with error messaging

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -129,6 +129,19 @@ def create_user():
     db.session.commit()
     return jsonify({"id": user.id, "username": user.username}), 201
 
+
+@app.route("/api/login", methods=["POST"])
+def login_user():
+    data = request.get_json() or {}
+    username = data.get("username")
+    password = data.get("password")
+    if not username or not password:
+        return jsonify({"error": "username and password required"}), 400
+    user = User.query.filter_by(username=username).first()
+    if not user or not user.check_password(password):
+        return jsonify({"error": "invalid credentials"}), 401
+    return jsonify({"id": user.id, "username": user.username})
+
 @socketio.on("start_download")
 def handle_start_download(data):
     domain = data.get("domain")

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -201,6 +201,9 @@
     <!-- Login Modal -->
     <div id="login-modal"
         class="bg-black/50 absolute top-0 left-0 size-full opacity-0 pointer-events-none transition-opacity flex items-center justify-center">
+        <button type="button" onclick="hideLoginModal()" class="absolute top-5 right-5 text-white">
+            <span class="material-symbols-rounded text-3xl">close</span>
+        </button>
         <form onsubmit="logIn(event)" class="bg-white p-10 rounded-3xl flex flex-col gap-2">
             <h2 class="text-2xl mb-2">Login</h2>
             <span id="login-error-message" class="text-red-600"></span>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -41,7 +41,7 @@
             <!-- form di ricerca -->
             <form class="relative h-1/3 w-full flex items-center justify-center transition-all duration-700">
                 <div class="flex flex-col items-center w-96 -translate-y-32 md:-translate-y-0">
-                    <h1 class="text-4xl text-center mb-10 text-pretty">Cosa vuoi scaricare?</h1>
+                    <h1 id="main-title" class="text-4xl text-center mb-10 text-pretty">Cosa vuoi scaricare?</h1>
                     <div class="flex items-center gap-2 border-2 border-gray-200 rounded-full p-2 pl-8 w-full">
                         <input type="text" placeholder="Titolo del film / serie tv" autofocus enterkeyhint="search"
                             class="outline-none w-full">
@@ -201,12 +201,12 @@
     <!-- Login Modal -->
     <div id="login-modal"
         class="bg-black/50 absolute top-0 left-0 size-full opacity-0 pointer-events-none transition-opacity flex items-center justify-center">
-        <form onclick="logIn()" class="bg-white p-10 rounded-3xl flex flex-col gap-2">
+        <form onsubmit="logIn(event)" class="bg-white p-10 rounded-3xl flex flex-col gap-2">
             <h2 class="text-2xl mb-2">Login</h2>
             <span id="login-error-message" class="text-red-600"></span>
             <input type="text" name="username" id="" placeholder="Username" class="rounded-xl border-2 px-3 py-2">
             <input type="password" name="username" id="" placeholder="Password" class="rounded-xl border-2 px-3 py-2">
-            <button onclick="signIn()" class="text-blue-600">Crea un account</button>
+            <button type="button" onclick="signIn()" class="text-blue-600">Crea un account</button>
             <input type="submit" value="Login" class="bg-blue-500 text-white font-semibold rounded-lg px-3 py-2 cursor-pointer">
         </form>
     </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -204,7 +204,7 @@
         <button type="button" onclick="hideLoginModal()" class="absolute top-5 right-5 text-white">
             <span class="material-symbols-rounded text-3xl">close</span>
         </button>
-        <form onsubmit="logIn(event)" class="bg-white p-10 rounded-3xl flex flex-col gap-2">
+        <form id="login-form" onsubmit="logIn(event)" class="bg-white p-10 rounded-3xl flex flex-col gap-2">
             <h2 class="text-2xl mb-2">Login</h2>
             <span id="login-error-message" class="text-red-600"></span>
             <input type="text" name="username" id="" placeholder="Username" class="rounded-xl border-2 px-3 py-2">
@@ -212,6 +212,9 @@
             <button type="button" onclick="signIn()" class="text-blue-600">Crea un account</button>
             <input type="submit" value="Login" class="bg-blue-500 text-white font-semibold rounded-lg px-3 py-2 cursor-pointer">
         </form>
+        <div id="logout-container" class="bg-white p-10 rounded-3xl flex flex-col gap-2 hidden">
+            <button type="button" onclick="logOut()" class="bg-blue-500 text-white font-semibold rounded-lg px-3 py-2 cursor-pointer">Logout</button>
+        </div>
     </div>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.1/socket.io.js"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -205,7 +205,7 @@
             <h2 class="text-2xl mb-2">Login</h2>
             <span id="login-error-message" class="text-red-600"></span>
             <input type="text" name="username" id="" placeholder="Username" class="rounded-xl border-2 px-3 py-2">
-            <input type="password" name="username" id="" placeholder="Password" class="rounded-xl border-2 px-3 py-2">
+            <input type="password" name="password" id="" placeholder="Password" class="rounded-xl border-2 px-3 py-2">
             <button type="button" onclick="signIn()" class="text-blue-600">Crea un account</button>
             <input type="submit" value="Login" class="bg-blue-500 text-white font-semibold rounded-lg px-3 py-2 cursor-pointer">
         </form>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -203,6 +203,7 @@
         class="bg-black/50 absolute top-0 left-0 size-full opacity-0 pointer-events-none transition-opacity flex items-center justify-center">
         <form onclick="logIn()" class="bg-white p-10 rounded-3xl flex flex-col gap-2">
             <h2 class="text-2xl mb-2">Login</h2>
+            <span id="login-error-message" class="text-red-600"></span>
             <input type="text" name="username" id="" placeholder="Username" class="rounded-xl border-2 px-3 py-2">
             <input type="password" name="username" id="" placeholder="Password" class="rounded-xl border-2 px-3 py-2">
             <button onclick="signIn()" class="text-blue-600">Crea un account</button>

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -37,8 +37,17 @@ async function fetchStreamingLinks(id, episodeId = null) {
     return data;
 }
 
-async function fetchSignIn() {
-
+async function fetchSignIn(username, password) {
+    const res = await fetch('/api/users', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+    });
+    const data = await res.json();
+    if (!res.ok) {
+        throw new Error(data.error || 'Errore nella creazione dell\'account');
+    }
+    return data;
 }
 
 async function fetchLogIn() {

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -50,8 +50,17 @@ async function fetchSignIn(username, password) {
     return data;
 }
 
-async function fetchLogIn() {
-
+async function fetchLogIn(username, password) {
+    const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+    });
+    const data = await res.json();
+    if (!res.ok) {
+        throw new Error(data.error || 'Credenziali non valide');
+    }
+    return data;
 }
 
 async function checkDomainReachable(domain) {

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -183,6 +183,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     updateNoDownloadsMessage();
     checkVersions();
 
+    const storedUser = localStorage.getItem('username');
+    if (storedUser) {
+        updateMainTitle(storedUser);
+    }
+
     const form = document.querySelector('form');
     const downloadBtn = document.getElementById('download-btn');
     const watchBtn = document.getElementById('watch-btn');

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -5,10 +5,22 @@ function toggleMobileMenu() {
 
 function showLoginModal() {
     const modal = document.getElementById('login-modal');
+    const form = document.getElementById('login-form');
+    const logoutContainer = document.getElementById('logout-container');
+    const username = localStorage.getItem('username');
+    if (username) {
+        if (form) form.classList.add('hidden');
+        if (logoutContainer) logoutContainer.classList.remove('hidden');
+    } else {
+        if (logoutContainer) logoutContainer.classList.add('hidden');
+        if (form) {
+            form.classList.remove('hidden');
+            const usernameInput = form.querySelector('input[name="username"]');
+            if (usernameInput) usernameInput.focus();
+        }
+    }
     modal.classList.remove('opacity-0');
     modal.classList.remove('pointer-events-none');
-    const usernameInput = modal.querySelector('input[name="username"]');
-    if (usernameInput) usernameInput.focus();
 }
 
 function hideLoginModal() {
@@ -21,6 +33,10 @@ function hideLoginModal() {
     if (usernameInput) usernameInput.value = '';
     if (passwordInput) passwordInput.value = '';
     if (errorEl) errorEl.textContent = '';
+    const form = document.getElementById('login-form');
+    const logoutContainer = document.getElementById('logout-container');
+    if (form) form.classList.remove('hidden');
+    if (logoutContainer) logoutContainer.classList.add('hidden');
 }
 
 document.addEventListener('keydown', (event) => {
@@ -433,6 +449,12 @@ async function signIn() {
         errorEl.classList.add('text-red-600');
         errorEl.textContent = err.message;
     }
+}
+
+function logOut() {
+    localStorage.removeItem('username');
+    updateMainTitle();
+    hideLoginModal();
 }
 
 function startSearchLoading() {

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -4,21 +4,33 @@ function toggleMobileMenu() {
 }
 
 function showLoginModal() {
-    document.getElementById('login-modal').classList.remove('opacity-0');
-    document.getElementById('login-modal').classList.remove('pointer-events-none');
+    const modal = document.getElementById('login-modal');
+    modal.classList.remove('opacity-0');
+    modal.classList.remove('pointer-events-none');
+    const usernameInput = modal.querySelector('input[name="username"]');
+    if (usernameInput) usernameInput.focus();
 }
 
 function hideLoginModal() {
     const modal = document.getElementById('login-modal');
     modal.classList.add('opacity-0');
     modal.classList.add('pointer-events-none');
-    const usernameInput = modal.querySelector('input[type="text"]');
+    const usernameInput = modal.querySelector('input[name="username"]');
     const passwordInput = modal.querySelector('input[type="password"]');
     const errorEl = document.getElementById('login-error-message');
     if (usernameInput) usernameInput.value = '';
     if (passwordInput) passwordInput.value = '';
     if (errorEl) errorEl.textContent = '';
 }
+
+document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+        const modal = document.getElementById('login-modal');
+        if (modal && !modal.classList.contains('pointer-events-none')) {
+            hideLoginModal();
+        }
+    }
+});
 
 function updateMainTitle(username) {
     const title = document.getElementById('main-title');

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -354,8 +354,25 @@ function logIn() {
 
 }
 
-function signIn() {
-    
+async function signIn() {
+    event.preventDefault();
+    const usernameInput = document.querySelector('#login-modal input[type="text"]');
+    const passwordInput = document.querySelector('#login-modal input[type="password"]');
+    const username = usernameInput.value.trim();
+    const password = passwordInput.value.trim();
+    const errorEl = document.getElementById('login-error-message');
+    errorEl.textContent = '';
+    if (!username || !password) {
+        errorEl.textContent = 'Username e password sono obbligatori';
+        return;
+    }
+    try {
+        await fetchSignIn(username, password);
+        usernameInput.value = '';
+        passwordInput.value = '';
+    } catch (err) {
+        errorEl.textContent = err.message;
+    }
 }
 
 function startSearchLoading() {

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -392,6 +392,8 @@ async function logIn(event) {
     const password = passwordInput.value.trim();
     const errorEl = document.getElementById('login-error-message');
     errorEl.textContent = '';
+    errorEl.classList.remove('text-green-600');
+    errorEl.classList.add('text-red-600');
     if (!username || !password) {
         errorEl.textContent = 'Username e password sono obbligatori';
         return;
@@ -407,13 +409,14 @@ async function logIn(event) {
 }
 
 async function signIn() {
-    event.preventDefault();
     const usernameInput = document.querySelector('#login-modal input[type="text"]');
     const passwordInput = document.querySelector('#login-modal input[type="password"]');
     const username = usernameInput.value.trim();
     const password = passwordInput.value.trim();
     const errorEl = document.getElementById('login-error-message');
     errorEl.textContent = '';
+    errorEl.classList.remove('text-green-600');
+    errorEl.classList.add('text-red-600');
     if (!username || !password) {
         errorEl.textContent = 'Username e password sono obbligatori';
         return;
@@ -422,7 +425,12 @@ async function signIn() {
         await fetchSignIn(username, password);
         usernameInput.value = '';
         passwordInput.value = '';
+        errorEl.classList.remove('text-red-600');
+        errorEl.classList.add('text-green-600');
+        errorEl.textContent = 'Account creato con successo';
     } catch (err) {
+        errorEl.classList.remove('text-green-600');
+        errorEl.classList.add('text-red-600');
         errorEl.textContent = err.message;
     }
 }

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -8,6 +8,16 @@ function showLoginModal() {
     document.getElementById('login-modal').classList.remove('pointer-events-none');
 }
 
+function updateMainTitle(username) {
+    const title = document.getElementById('main-title');
+    if (!title) return;
+    if (username) {
+        title.textContent = `Ciao ${username}, cosa vuoi scaricare?`;
+    } else {
+        title.textContent = 'Cosa vuoi scaricare?';
+    }
+}
+
 async function getLatestReleaseVersion() {
   const url = 'https://api.github.com/repos/riccardo-florio/stre-web-app/releases/latest';
 
@@ -350,8 +360,29 @@ function createDownloadItem(id, title) {
     updateNoDownloadsMessage();
 }
 
-function logIn() {
-
+async function logIn(event) {
+    event.preventDefault();
+    const usernameInput = document.querySelector('#login-modal input[type="text"]');
+    const passwordInput = document.querySelector('#login-modal input[type="password"]');
+    const username = usernameInput.value.trim();
+    const password = passwordInput.value.trim();
+    const errorEl = document.getElementById('login-error-message');
+    errorEl.textContent = '';
+    if (!username || !password) {
+        errorEl.textContent = 'Username e password sono obbligatori';
+        return;
+    }
+    try {
+        await fetchLogIn(username, password);
+        localStorage.setItem('username', username);
+        updateMainTitle(username);
+        document.getElementById('login-modal').classList.add('opacity-0');
+        document.getElementById('login-modal').classList.add('pointer-events-none');
+        usernameInput.value = '';
+        passwordInput.value = '';
+    } catch (err) {
+        errorEl.textContent = err.message;
+    }
 }
 
 async function signIn() {

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -8,6 +8,18 @@ function showLoginModal() {
     document.getElementById('login-modal').classList.remove('pointer-events-none');
 }
 
+function hideLoginModal() {
+    const modal = document.getElementById('login-modal');
+    modal.classList.add('opacity-0');
+    modal.classList.add('pointer-events-none');
+    const usernameInput = modal.querySelector('input[type="text"]');
+    const passwordInput = modal.querySelector('input[type="password"]');
+    const errorEl = document.getElementById('login-error-message');
+    if (usernameInput) usernameInput.value = '';
+    if (passwordInput) passwordInput.value = '';
+    if (errorEl) errorEl.textContent = '';
+}
+
 function updateMainTitle(username) {
     const title = document.getElementById('main-title');
     if (!title) return;
@@ -376,10 +388,7 @@ async function logIn(event) {
         await fetchLogIn(username, password);
         localStorage.setItem('username', username);
         updateMainTitle(username);
-        document.getElementById('login-modal').classList.add('opacity-0');
-        document.getElementById('login-modal').classList.add('pointer-events-none');
-        usernameInput.value = '';
-        passwordInput.value = '';
+        hideLoginModal();
     } catch (err) {
         errorEl.textContent = err.message;
     }


### PR DESCRIPTION
## Summary
- add error message placeholder to login modal
- implement frontend sign-up API call and UI handler

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b4ec5787483339e6759d257f80ccb