### PR TITLE
Add backend HLS proxy and Safari-friendly player

### DIFF
--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -221,7 +221,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             const links = await fetchStreamingLinks(filmId);
             const hlsLink = links.find(l => l.includes('playlist') || l.includes('.m3u8'));
             if (hlsLink) {
-                showPlayer(hlsLink, filmId);
+                const prox = `/proxy-hls?u=${encodeURIComponent(hlsLink)}`;
+                showPlayer(prox, filmId);
             } else {
                 alert('Nessun link disponibile');
             }

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -151,12 +151,16 @@ function populateSearchResultError() {
     resultsCardsContainer.innerHTML = `<p class="text-red-500 text-pretty">Errore nella ricerca. Riprova più tardi.</p>`;
 }
 
+function proxiedHls(url) {
+    return url ? `/proxy-hls?u=${encodeURIComponent(url)}` : url;
+}
+
 async function watchFromSearch(id) {
     try {
         const links = await fetchStreamingLinks(id);
         const hlsLink = links.find(l => l.includes('playlist') || l.includes('.m3u8'));
         if (hlsLink) {
-            showPlayer(hlsLink, id);
+            showPlayer(proxiedHls(hlsLink), id);
         } else {
             alert('Nessun link disponibile');
         }
@@ -245,7 +249,7 @@ async function populateDownloadSection(slug, title) {
                         const links = await fetchStreamingLinks(filmId, ep.id);
                         const hlsLink = links.find(l => l.includes('playlist') || l.includes('.m3u8'));
                         if (hlsLink) {
-                            showPlayer(hlsLink, ep.id);
+                            showPlayer(proxiedHls(hlsLink), ep.id);
                         } else {
                             alert('Nessun link disponibile');
                         }
@@ -290,33 +294,6 @@ async function populateDownloadSection(slug, title) {
         watchBtn.classList.remove('hidden');
         updateWatchButtonLabel(filmId);
     }
-}
-
-function showPlayer(src) {
-    const modal = document.getElementById('player-modal');
-    const video = document.getElementById('video-player');
-    modal.classList.remove('hidden');
-
-    if (Hls.isSupported()) {
-        const hls = new Hls();
-        hls.loadSource(src);
-        hls.attachMedia(video);
-        video.hlsInstance = hls;
-    } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
-        video.src = src;
-    }
-}
-
-function hidePlayer() {
-    const modal = document.getElementById('player-modal');
-    const video = document.getElementById('video-player');
-    modal.classList.add('hidden');
-    if (video.hlsInstance) {
-        video.hlsInstance.destroy();
-        video.hlsInstance = null;
-    }
-    video.pause();
-    video.removeAttribute('src');
 }
 
 function updateDownloadProgress(id, percent, eta = null, downloaded = null, total = null, speed = null) {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 streamingcommunity-unofficialapi
-requests
+requests>=2.32
 yt_dlp
 pycryptodomex
 https://github.com/Blu-Tiger/StreamingCommunity-yt-dlp-plugin/archive/master.zip


### PR DESCRIPTION
## Summary
- Proxy HLS playlists and segments server-side with configurable referer and range support
- Use proxied playlist URLs from the UI and watch actions
- Prefer native HLS on Safari/iOS with muted autoplay and Hls.js fallback elsewhere

## Testing
- `python -m py_compile backend/app.py`
- `node --check frontend/js/ui.js`
- `node --check frontend/js/app.js`
- `node --check frontend/js/player.js`


------
https://chatgpt.com/codex/tasks/task_e_689b6294d7e48333b8151484ba71778b