### PR TITLE
fix: require user gesture for inline playback

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -186,7 +186,7 @@
                 </g>
             </svg>
         </div>
-        <video id="video-player" class="w-full h-full object-contain"></video>
+        <video id="video-player" class="w-full h-full object-contain" playsinline webkit-playsinline></video>
         <div id="player-controls"
             class="absolute bottom-0 left-0 right-0 flex items-center gap-4 p-4 bg-black/60 transition-opacity duration-300">
             <button id="play-pause" class="text-white material-symbols-rounded text-3xl">play_arrow</button>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -216,19 +216,20 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
     });
 
-    watchBtn.addEventListener('click', async () => {
-        try {
-            const links = await fetchStreamingLinks(filmId);
-            const hlsLink = links.find(l => l.includes('playlist') || l.includes('.m3u8'));
-            if (hlsLink) {
-                showPlayer(hlsLink, filmId);
-            } else {
-                alert('Nessun link disponibile');
-            }
-        } catch (err) {
-            console.error('Errore nel recupero dei link', err);
-            alert('Errore nel recupero dei link');
-        }
+    watchBtn.addEventListener('click', () => {
+        fetchStreamingLinks(filmId)
+            .then(links => {
+                const hlsLink = links.find(l => l.includes('playlist') || l.includes('.m3u8'));
+                if (hlsLink) {
+                    showPlayer(hlsLink, filmId);
+                } else {
+                    alert('Nessun link disponibile');
+                }
+            })
+            .catch(err => {
+                console.error('Errore nel recupero dei link', err);
+                alert('Errore nel recupero dei link');
+            });
     });
 
     handleNavigationFromURL();

--- a/frontend/js/player.js
+++ b/frontend/js/player.js
@@ -58,12 +58,12 @@
             video.removeEventListener('loadedmetadata', init);
         });
 
-        video.play();
         if (modal.requestFullscreen) {
             modal.requestFullscreen();
         }
         showControls();
         updateWatchButtonLabel();
+        updatePlayButton();
     }
 
     function hidePlayer(popState = false) {
@@ -95,7 +95,12 @@
 
     function togglePlay() {
         if (video.paused) {
-            video.play();
+            const playPromise = video.play();
+            if (playPromise !== undefined) {
+                playPromise.catch(() => {
+                    alert('Riproduzione bloccata, tocca per riprovare.');
+                });
+            }
         } else {
             video.pause();
         }


### PR DESCRIPTION
## Summary
- ensure watch action doesn't await before opening player
- require explicit user interaction to start playback and handle play() rejection
- enable inline playback on iOS

## Testing
- `node --check frontend/js/app.js`
- `node --check frontend/js/player.js`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689b6ee1171c83339ab2c5fa40cf84b4