### PR TITLE
feat: add backend auth and registration

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -68,9 +68,22 @@ def ensure_video_progress_columns():
     db.session.commit()
 
 
+def ensure_user_columns():
+    info = db.session.execute(text("PRAGMA table_info(user)"))
+    columns = [row[1] for row in info]
+    if "email" not in columns:
+        db.session.execute(text("ALTER TABLE user ADD COLUMN email VARCHAR(120)"))
+    if "first_name" not in columns:
+        db.session.execute(text("ALTER TABLE user ADD COLUMN first_name VARCHAR(120)"))
+    if "last_name" not in columns:
+        db.session.execute(text("ALTER TABLE user ADD COLUMN last_name VARCHAR(120)"))
+    db.session.commit()
+
+
 with app.app_context():
     db.create_all()
     ensure_video_progress_columns()
+    ensure_user_columns()
 
 socketio = SocketIO(app)
 
@@ -143,11 +156,21 @@ def create_user():
     data = request.get_json() or {}
     username = data.get("username")
     password = data.get("password")
-    if not username or not password:
-        return jsonify({"error": "username and password required"}), 400
+    nome = data.get("nome")
+    cognome = data.get("cognome")
+    email = data.get("email")
+    if not all([username, password, nome, cognome, email]):
+        return jsonify({"error": "missing required fields"}), 400
     if User.query.filter_by(username=username).first():
         return jsonify({"error": "username already exists"}), 400
-    user = User(username=username)
+    if User.query.filter_by(email=email).first():
+        return jsonify({"error": "email already exists"}), 400
+    user = User(
+        username=username,
+        email=email,
+        first_name=nome,
+        last_name=cognome,
+    )
     user.set_password(password)
     db.session.add(user)
     db.session.commit()
@@ -165,6 +188,11 @@ def login_user():
     if not user or not user.check_password(password):
         return jsonify({"error": "invalid credentials"}), 401
     return jsonify({"id": user.id, "username": user.username})
+
+
+@app.route("/api/logout", methods=["POST"])
+def logout_user():
+    return jsonify({"status": "logged out"})
 
 
 @app.route("/api/progress/<int:user_id>/<film_id>", methods=["GET", "POST"])

--- a/backend/models.py
+++ b/backend/models.py
@@ -9,6 +9,9 @@ db = SQLAlchemy()
 class User(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(80), unique=True, nullable=False)
+    email = db.Column(db.String(120), unique=True, nullable=False)
+    first_name = db.Column(db.String(120), nullable=False)
+    last_name = db.Column(db.String(120), nullable=False)
     password_hash = db.Column(db.String(255), nullable=False)
 
     def set_password(self, password: str) -> None:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -135,7 +135,7 @@
                 close
             </span>
         </button>
-        <button onclick="showLoginModal()" class="absolute right-20 lg:right-10 top-9">
+        <button onclick="handleAccountModal()" class="absolute right-20 lg:right-10 top-9">
             <span class="material-symbols-rounded text-3xl text-blue-600">
                 person
             </span>
@@ -211,13 +211,41 @@
         <form id="login-form" onsubmit="logIn(event)" class="bg-white p-10 rounded-3xl flex flex-col gap-2">
             <h2 class="text-2xl mb-2">Login</h2>
             <span id="login-error-message" class="text-red-600"></span>
-            <input type="text" name="username" id="" placeholder="Username" class="rounded-xl border-2 px-3 py-2">
-            <input type="password" name="password" id="" placeholder="Password" class="rounded-xl border-2 px-3 py-2">
-            <button type="button" onclick="signIn()" class="text-blue-600">Crea un account</button>
+            <input type="text" name="username" placeholder="Username" class="rounded-xl border-2 px-3 py-2">
+            <input type="password" name="password" placeholder="Password" class="rounded-xl border-2 px-3 py-2">
+            <button type="button" onclick="showRegisterModal()" class="text-blue-600">Crea un account</button>
             <input type="submit" value="Login" class="bg-blue-500 text-white font-semibold rounded-lg px-3 py-2 cursor-pointer">
         </form>
-        <div id="logout-container" class="bg-white p-10 rounded-3xl flex flex-col gap-2 hidden">
-            <button type="button" onclick="logOut()" class="bg-blue-500 text-white font-semibold rounded-lg px-3 py-2 cursor-pointer">Logout</button>
+    </div>
+
+    <!-- Registration Modal -->
+    <div id="register-modal"
+        class="bg-black/50 absolute top-0 left-0 size-full opacity-0 pointer-events-none transition-opacity flex items-center justify-center">
+        <button type="button" onclick="hideRegisterModal()" class="absolute top-5 right-5 text-white">
+            <span class="material-symbols-rounded text-3xl">close</span>
+        </button>
+          <form id="registration-form" onsubmit="register(event)" class="bg-white p-10 rounded-3xl flex flex-col gap-2">
+              <h2 class="text-2xl mb-2">Registrazione</h2>
+              <span id="register-error-message" class="text-red-600"></span>
+              <input type="text" name="nome" placeholder="Nome" class="rounded-xl border-2 px-3 py-2">
+              <input type="text" name="cognome" placeholder="Cognome" class="rounded-xl border-2 px-3 py-2">
+              <input type="text" name="username" placeholder="Username" class="rounded-xl border-2 px-3 py-2">
+              <input type="email" name="email" placeholder="Email" class="rounded-xl border-2 px-3 py-2">
+              <input type="password" name="password" placeholder="Password" class="rounded-xl border-2 px-3 py-2">
+              <button type="button" onclick="hideRegisterModal(); showLoginModal();" class="text-blue-600">Hai già un account? Accedi</button>
+              <input type="submit" value="Registrati" class="bg-blue-500 text-white font-semibold rounded-lg px-3 py-2 cursor-pointer">
+          </form>
+      </div>
+
+    <!-- Logout Modal -->
+    <div id="logout-modal"
+        class="bg-black/50 absolute top-0 left-0 size-full opacity-0 pointer-events-none transition-opacity flex items-center justify-center">
+        <div class="bg-white p-10 rounded-3xl flex flex-col gap-4 items-center">
+            <span class="text-xl">Vuoi uscire?</span>
+            <div class="flex gap-4">
+                <button type="button" onclick="hideLogoutModal()" class="px-3 py-2 rounded-lg border">Annulla</button>
+                <button type="button" onclick="logOut()" class="bg-blue-500 text-white font-semibold rounded-lg px-3 py-2">Logout</button>
+            </div>
         </div>
     </div>
 

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -37,11 +37,11 @@ async function fetchStreamingLinks(id, episodeId = null) {
     return data;
 }
 
-async function fetchSignIn(username, password) {
+async function fetchSignIn(nome, cognome, username, email, password) {
     const res = await fetch('/api/users', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username, password })
+        body: JSON.stringify({ nome, cognome, username, email, password })
     });
     const data = await res.json();
     if (!res.ok) {

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -3,32 +3,24 @@ function toggleMobileMenu() {
     document.getElementById('download-tab').classList.toggle('pointer-events-none');
 }
 
-function showLoginModal() {
-    const modal = document.getElementById('login-modal');
-    const form = document.getElementById('login-form');
-    const logoutContainer = document.getElementById('logout-container');
-    const closeBtn = modal.querySelector('button[onclick="hideLoginModal()"]');
+function handleAccountModal() {
     const username = localStorage.getItem('username');
     if (username) {
-        if (form) form.classList.add('hidden');
-        if (logoutContainer) logoutContainer.classList.remove('hidden');
-        if (closeBtn) closeBtn.classList.remove('hidden');
+        showLogoutModal();
     } else {
-        if (logoutContainer) logoutContainer.classList.add('hidden');
-        if (form) {
-            form.classList.remove('hidden');
-            const usernameInput = form.querySelector('input[name="username"]');
-            if (usernameInput) usernameInput.focus();
-        }
-        if (closeBtn) closeBtn.classList.add('hidden');
+        showLoginModal();
     }
+}
+
+function showLoginModal() {
+    const modal = document.getElementById('login-modal');
     modal.classList.remove('opacity-0');
     modal.classList.remove('pointer-events-none');
+    const usernameInput = modal.querySelector('input[name="username"]');
+    if (usernameInput) usernameInput.focus();
 }
 
 function hideLoginModal() {
-    const username = localStorage.getItem('username');
-    if (!username) return;
     const modal = document.getElementById('login-modal');
     modal.classList.add('opacity-0');
     modal.classList.add('pointer-events-none');
@@ -38,18 +30,75 @@ function hideLoginModal() {
     if (usernameInput) usernameInput.value = '';
     if (passwordInput) passwordInput.value = '';
     if (errorEl) errorEl.textContent = '';
-    const form = document.getElementById('login-form');
-    const logoutContainer = document.getElementById('logout-container');
-    if (form) form.classList.remove('hidden');
-    if (logoutContainer) logoutContainer.classList.add('hidden');
+}
+
+function showRegisterModal() {
+    hideLoginModal();
+    const modal = document.getElementById('register-modal');
+    modal.classList.remove('opacity-0');
+    modal.classList.remove('pointer-events-none');
+    const nameInput = modal.querySelector('input[name="nome"]');
+    if (nameInput) nameInput.focus();
+}
+
+function hideRegisterModal() {
+    const modal = document.getElementById('register-modal');
+    modal.classList.add('opacity-0');
+    modal.classList.add('pointer-events-none');
+    modal.querySelectorAll('input').forEach(input => {
+        if (input.type !== 'submit') input.value = '';
+    });
+    const errorEl = document.getElementById('register-error-message');
+    if (errorEl) errorEl.textContent = '';
+}
+
+function showLogoutModal() {
+    const modal = document.getElementById('logout-modal');
+    modal.classList.remove('opacity-0');
+    modal.classList.remove('pointer-events-none');
+}
+
+function hideLogoutModal() {
+    const modal = document.getElementById('logout-modal');
+    modal.classList.add('opacity-0');
+    modal.classList.add('pointer-events-none');
+}
+
+async function register(event) {
+    event.preventDefault();
+    const form = document.getElementById('registration-form');
+    const nome = form.querySelector('input[name="nome"]').value.trim();
+    const cognome = form.querySelector('input[name="cognome"]').value.trim();
+    const username = form.querySelector('input[name="username"]').value.trim();
+    const email = form.querySelector('input[name="email"]').value.trim();
+    const password = form.querySelector('input[name="password"]').value.trim();
+    const errorEl = document.getElementById('register-error-message');
+    if (errorEl) {
+        errorEl.textContent = '';
+        errorEl.classList.remove('text-green-600');
+        errorEl.classList.add('text-red-600');
+    }
+    if (!nome || !cognome || !username || !email || !password) {
+        if (errorEl) errorEl.textContent = 'Tutti i campi sono obbligatori';
+        return;
+    }
+    try {
+        const data = await fetchSignIn(nome, cognome, username, email, password);
+        localStorage.setItem('username', data.username);
+        localStorage.setItem('userId', data.id);
+        updateMainTitle(data.username);
+        hideRegisterModal();
+        populateContinueWatching();
+    } catch (err) {
+        if (errorEl) errorEl.textContent = err.message;
+    }
 }
 
 document.addEventListener('keydown', (event) => {
     if (event.key === 'Escape') {
-        const modal = document.getElementById('login-modal');
-        if (modal && !modal.classList.contains('pointer-events-none')) {
-            hideLoginModal();
-        }
+        hideLoginModal();
+        hideRegisterModal();
+        hideLogoutModal();
     }
 });
 
@@ -483,38 +532,14 @@ async function logIn(event) {
     }
 }
 
-async function signIn() {
-    const usernameInput = document.querySelector('#login-modal input[type="text"]');
-    const passwordInput = document.querySelector('#login-modal input[type="password"]');
-    const username = usernameInput.value.trim();
-    const password = passwordInput.value.trim();
-    const errorEl = document.getElementById('login-error-message');
-    errorEl.textContent = '';
-    errorEl.classList.remove('text-green-600');
-    errorEl.classList.add('text-red-600');
-    if (!username || !password) {
-        errorEl.textContent = 'Username e password sono obbligatori';
-        return;
-    }
+async function logOut() {
     try {
-        await fetchSignIn(username, password);
-        usernameInput.value = '';
-        passwordInput.value = '';
-        errorEl.classList.remove('text-red-600');
-        errorEl.classList.add('text-green-600');
-        errorEl.textContent = 'Account creato con successo';
-    } catch (err) {
-        errorEl.classList.remove('text-green-600');
-        errorEl.classList.add('text-red-600');
-        errorEl.textContent = err.message;
-    }
-}
-
-function logOut() {
+        await fetch('/api/logout', { method: 'POST' });
+    } catch (_) {}
     localStorage.removeItem('username');
     localStorage.removeItem('userId');
     updateMainTitle();
-    showLoginModal();
+    hideLogoutModal();
     populateContinueWatching();
 }
 


### PR DESCRIPTION
## Summary
- store user names and emails alongside credentials
- handle registration and logout through new backend endpoints
- wire frontend modals to authentication APIs

## Testing
- `python -m py_compile backend/app.py backend/models.py`
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a20e4b34fc8333b4b26f637646f724