### PR TITLE
Add admin user management dashboard

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -218,13 +218,24 @@ def create_user():
     ), 201
 
 
-@app.route("/api/users/<int:user_id>", methods=["PUT", "DELETE"])
+@app.route("/api/users/<int:user_id>", methods=["GET", "PUT", "DELETE"])
 def manage_user(user_id):
-    if not is_admin_request():
-        return jsonify({"error": "forbidden"}), 403
     user = User.query.get(user_id)
     if not user:
         return jsonify({"error": "user not found"}), 404
+
+    if request.method == "GET":
+        return jsonify({
+            "id": user.id,
+            "username": user.username,
+            "first_name": user.first_name,
+            "last_name": user.last_name,
+            "email": user.email,
+            "role": user.role,
+        })
+
+    if not is_admin_request():
+        return jsonify({"error": "forbidden"}), 403
 
     if request.method == "DELETE":
         db.session.delete(user)

--- a/backend/app.py
+++ b/backend/app.py
@@ -156,8 +156,31 @@ def get_streaming_links(content_id):
     return jsonify(results)
 
 
-@app.route("/api/users", methods=["POST"])
+def is_admin_request() -> bool:
+    """Return True if the request is performed by an admin user."""
+    return request.headers.get("X-Role") == "admin"
+
+
+@app.route("/api/users", methods=["POST", "GET"])
 def create_user():
+    if request.method == "GET":
+        if not is_admin_request():
+            return jsonify({"error": "forbidden"}), 403
+        users = User.query.all()
+        return jsonify(
+            [
+                {
+                    "id": u.id,
+                    "username": u.username,
+                    "first_name": u.first_name,
+                    "last_name": u.last_name,
+                    "email": u.email,
+                    "role": u.role,
+                }
+                for u in users
+            ]
+        )
+
     data = request.get_json() or {}
     username = data.get("username")
     password = data.get("password")
@@ -183,14 +206,59 @@ def create_user():
     user.set_password(password)
     db.session.add(user)
     db.session.commit()
-    return jsonify({
-        "id": user.id,
-        "username": user.username,
-        "first_name": user.first_name,
-        "last_name": user.last_name,
-        "email": user.email,
-        "role": user.role,
-    }), 201
+    return jsonify(
+        {
+            "id": user.id,
+            "username": user.username,
+            "first_name": user.first_name,
+            "last_name": user.last_name,
+            "email": user.email,
+            "role": user.role,
+        }
+    ), 201
+
+
+@app.route("/api/users/<int:user_id>", methods=["PUT", "DELETE"])
+def manage_user(user_id):
+    if not is_admin_request():
+        return jsonify({"error": "forbidden"}), 403
+    user = User.query.get(user_id)
+    if not user:
+        return jsonify({"error": "user not found"}), 404
+
+    if request.method == "DELETE":
+        db.session.delete(user)
+        db.session.commit()
+        return jsonify({"status": "deleted"})
+
+    data = request.get_json() or {}
+    first_name = data.get("first_name")
+    last_name = data.get("last_name")
+    email = data.get("email")
+    role = data.get("role")
+    if role and role not in {"admin", "privileged", "normal"}:
+        return jsonify({"error": "invalid role"}), 400
+    if first_name is not None:
+        user.first_name = first_name
+    if last_name is not None:
+        user.last_name = last_name
+    if email is not None:
+        if User.query.filter_by(email=email).filter(User.id != user_id).first():
+            return jsonify({"error": "email already exists"}), 400
+        user.email = email
+    if role is not None:
+        user.role = role
+    db.session.commit()
+    return jsonify(
+        {
+            "id": user.id,
+            "username": user.username,
+            "first_name": user.first_name,
+            "last_name": user.last_name,
+            "email": user.email,
+            "role": user.role,
+        }
+    )
 
 
 @app.route("/api/login", methods=["POST"])

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -276,7 +276,10 @@
             <span class="material-symbols-rounded text-3xl">close</span>
         </button>
         <div class="bg-white p-10 rounded-3xl w-full max-w-3xl">
-            <h2 class="text-2xl mb-4">Gestione Utenti</h2>
+            <div class="flex items-center justify-between mb-4">
+                <h2 class="text-2xl">Gestione Utenti</h2>
+                <button type="button" onclick="populateUserTable()" class="bg-gray-500 text-white px-3 py-1 rounded">Ricarica</button>
+            </div>
             <div id="admin-users" class="overflow-y-auto max-h-[60vh]"></div>
         </div>
     </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -265,7 +265,7 @@
             </div>
             <button id="admin-dashboard-btn" type="button" onclick="showAdminModal()"
                 class="bg-gray-500 text-white font-semibold rounded-lg px-3 py-2 hidden">Gestisci Utenti</button>
-            <button type="button" onclick="logOut()" class="bg-blue-500 text-white font-semibold rounded-lg px-3 py-2">Logout</button>
+            <button type="button" onclick="confirmLogOut()" class="bg-blue-500 text-white font-semibold rounded-lg px-3 py-2">Logout</button>
         </div>
     </div>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -263,7 +263,21 @@
                 <span id="detail-email"></span>
                 <span id="detail-role" class="hidden"></span>
             </div>
+            <button id="admin-dashboard-btn" type="button" onclick="showAdminModal()"
+                class="bg-gray-500 text-white font-semibold rounded-lg px-3 py-2 hidden">Gestisci Utenti</button>
             <button type="button" onclick="logOut()" class="bg-blue-500 text-white font-semibold rounded-lg px-3 py-2">Logout</button>
+        </div>
+    </div>
+
+    <!-- Admin Dashboard Modal -->
+    <div id="admin-modal"
+        class="bg-black/50 absolute top-0 left-0 size-full opacity-0 pointer-events-none transition-opacity flex items-center justify-center z-30">
+        <button type="button" onclick="hideAdminModal()" class="absolute top-5 right-5 text-white">
+            <span class="material-symbols-rounded text-3xl">close</span>
+        </button>
+        <div class="bg-white p-10 rounded-3xl w-full max-w-3xl">
+            <h2 class="text-2xl mb-4">Gestione Utenti</h2>
+            <div id="admin-users" class="overflow-y-auto max-h-[60vh]"></div>
         </div>
     </div>
 

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -122,6 +122,16 @@ async function deleteUser(id) {
     return data;
 }
 
+
+async function fetchUser(id) {
+    const res = await fetch(`/api/users/${id}`);
+    const data = await res.json();
+    if (!res.ok) {
+        throw new Error(data.error || 'Errore nel recupero utente');
+    }
+    return data;
+}
+
 async function checkDomainReachable(domain) {
     try {
         const res = await fetch(`/api/check-domain/${domain}`);

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -83,6 +83,45 @@ async function saveVideoProgress(userId, filmId, progress, slug, title, cover, d
     });
 }
 
+async function fetchUsers() {
+    const res = await fetch('/api/users', {
+        headers: { 'X-Role': localStorage.getItem('role') || '' }
+    });
+    const data = await res.json();
+    if (!res.ok) {
+        throw new Error(data.error || 'Errore nel recupero degli utenti');
+    }
+    return data;
+}
+
+async function updateUser(id, first_name, last_name, email, role) {
+    const res = await fetch(`/api/users/${id}`, {
+        method: 'PUT',
+        headers: {
+            'Content-Type': 'application/json',
+            'X-Role': localStorage.getItem('role') || ''
+        },
+        body: JSON.stringify({ first_name, last_name, email, role })
+    });
+    const data = await res.json();
+    if (!res.ok) {
+        throw new Error(data.error || 'Errore nella modifica utente');
+    }
+    return data;
+}
+
+async function deleteUser(id) {
+    const res = await fetch(`/api/users/${id}`, {
+        method: 'DELETE',
+        headers: { 'X-Role': localStorage.getItem('role') || '' }
+    });
+    const data = await res.json();
+    if (!res.ok) {
+        throw new Error(data.error || 'Errore nella cancellazione utente');
+    }
+    return data;
+}
+
 async function checkDomainReachable(domain) {
     try {
         const res = await fetch(`/api/check-domain/${domain}`);

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -187,7 +187,22 @@ document.addEventListener('DOMContentLoaded', async () => {
     const storedUser = localStorage.getItem('username');
     const storedName = localStorage.getItem('first_name');
     const storedRole = localStorage.getItem('role');
+    const storedId = localStorage.getItem('userId');
     if (storedUser && storedName) {
+        if (storedId) {
+            try {
+                const current = await fetchUser(storedId);
+                if (!current || current.role !== storedRole) {
+                    await logOut();
+                    showLoginModal();
+                    return;
+                }
+            } catch (err) {
+                await logOut();
+                showLoginModal();
+                return;
+            }
+        }
         updateMainTitle(storedName);
     } else {
         showLoginModal();

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -206,7 +206,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             return;
         }
     } else {
-        showLoginModal();
+        localStorage.removeItem('role');
+        updateMainTitle();
     }
     updateRoleUI(localStorage.getItem('role'));
     populateContinueWatching();

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -184,30 +184,31 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
     updateNoDownloadsMessage();
     checkVersions();
-    const storedUser = localStorage.getItem('username');
-    const storedName = localStorage.getItem('first_name');
-    const storedRole = localStorage.getItem('role');
     const storedId = localStorage.getItem('userId');
-    if (storedUser && storedName) {
-        if (storedId) {
-            try {
-                const current = await fetchUser(storedId);
-                if (!current || current.role !== storedRole) {
-                    await logOut();
-                    showLoginModal();
-                    return;
-                }
-            } catch (err) {
+    const storedRole = localStorage.getItem('role');
+    if (storedId) {
+        try {
+            const current = await fetchUser(storedId);
+            if (!current || current.role !== storedRole) {
                 await logOut();
                 showLoginModal();
                 return;
             }
+            localStorage.setItem('username', current.username);
+            localStorage.setItem('first_name', current.first_name);
+            localStorage.setItem('last_name', current.last_name);
+            localStorage.setItem('email', current.email);
+            localStorage.setItem('role', current.role);
+            updateMainTitle(current.first_name);
+        } catch (err) {
+            await logOut();
+            showLoginModal();
+            return;
         }
-        updateMainTitle(storedName);
     } else {
         showLoginModal();
     }
-    updateRoleUI(storedRole);
+    updateRoleUI(localStorage.getItem('role'));
     populateContinueWatching();
 
     const form = document.querySelector('form');

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -63,15 +63,12 @@ function showUserModal() {
     const role = localStorage.getItem('role');
     const roleEl = document.getElementById('detail-role');
     const adminBtn = document.getElementById('admin-dashboard-btn');
-    if (role && role !== 'normal') {
+    if (role === 'admin') {
         roleEl.textContent = `Ruolo: ${role}`;
         roleEl.classList.remove('hidden');
-    } else {
-        roleEl.classList.add('hidden');
-    }
-    if (role === 'admin') {
         adminBtn.classList.remove('hidden');
     } else {
+        roleEl.classList.add('hidden');
         adminBtn.classList.add('hidden');
     }
 }
@@ -208,7 +205,7 @@ function updateMainTitle(firstName) {
     const title = document.getElementById('main-title');
     if (!title) return;
     const role = localStorage.getItem('role');
-    const action = role === 'normal' ? 'guardare' : 'scaricare';
+    const action = role === 'admin' ? 'scaricare' : 'guardare';
     if (firstName) {
         const formatted = firstName.charAt(0).toUpperCase() + firstName.slice(1).toLowerCase();
         title.textContent = `Ciao ${formatted}, cosa vuoi ${action}?`;
@@ -223,18 +220,18 @@ function updateRoleUI(role = localStorage.getItem('role')) {
     const mainAccountBtn = document.getElementById('main-account-btn');
     const mobileAccountBtn = document.getElementById('mobile-account-btn');
     const mobileMenuBtn = document.getElementById('mobile-menu-btn');
-    if (role === 'normal') {
-        if (downloadBtn) downloadBtn.classList.add('hidden');
-        if (downloadTab) downloadTab.classList.add('hidden');
-        if (mainAccountBtn) mainAccountBtn.classList.remove('hidden');
-        if (mobileAccountBtn) mobileAccountBtn.classList.remove('hidden');
-        if (mobileMenuBtn) mobileMenuBtn.classList.add('hidden');
-    } else {
+    if (role === 'admin') {
         if (downloadBtn) downloadBtn.classList.remove('hidden');
         if (downloadTab) downloadTab.classList.remove('hidden');
         if (mainAccountBtn) mainAccountBtn.classList.add('hidden');
         if (mobileAccountBtn) mobileAccountBtn.classList.add('hidden');
         if (mobileMenuBtn) mobileMenuBtn.classList.remove('hidden');
+    } else {
+        if (downloadBtn) downloadBtn.classList.add('hidden');
+        if (downloadTab) downloadTab.classList.add('hidden');
+        if (mainAccountBtn) mainAccountBtn.classList.remove('hidden');
+        if (mobileAccountBtn) mobileAccountBtn.classList.remove('hidden');
+        if (mobileMenuBtn) mobileMenuBtn.classList.add('hidden');
     }
 }
 
@@ -438,7 +435,7 @@ async function populateDownloadSection(slug, title) {
 
     const downloadBtn = document.getElementById('download-btn');
     const watchBtn = document.getElementById('watch-btn');
-    const isNormal = localStorage.getItem('role') === 'normal';
+    const isNormal = localStorage.getItem('role') !== 'admin';
 
     if (data.type == "tv") {
         const wrapper = document.getElementById('choose-episodes');

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -131,7 +131,19 @@ async function updateUserHandler(id) {
     const email = document.getElementById(`em-${id}`).value.trim();
     const role = document.getElementById(`rl-${id}`).value;
     try {
-        await updateUser(id, first_name, last_name, email, role);
+        const updated = await updateUser(id, first_name, last_name, email, role);
+        if (String(id) === localStorage.getItem('userId')) {
+            localStorage.setItem('first_name', updated.first_name);
+            localStorage.setItem('last_name', updated.last_name);
+            localStorage.setItem('email', updated.email);
+            localStorage.setItem('role', updated.role);
+            localStorage.setItem('username', updated.username);
+            updateMainTitle(updated.first_name);
+            updateRoleUI(updated.role);
+            if (updated.role !== 'admin') {
+                hideAdminModal();
+            }
+        }
         await populateUserTable();
     } catch (err) {
         alert(err.message);

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -667,6 +667,12 @@ async function logIn(event) {
     }
 }
 
+async function confirmLogOut() {
+    if (confirm('Sei sicuro di voler uscire?')) {
+        await logOut();
+    }
+}
+
 async function logOut() {
     try {
         await fetch('/api/logout', { method: 'POST' });


### PR DESCRIPTION
## Summary
- add admin-only endpoints to list, update and delete users
- build admin dashboard modal to manage users
- expose admin tools from user account modal

## Testing
- `python -m py_compile backend/app.py backend/models.py`


------
https://chatgpt.com/codex/tasks/task_e_68a321c64f00833389060a7e900a9ca2