### PR TITLE
Ignore SSL certificates for StreamingCommunity requests

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -31,12 +31,16 @@ class StreAPI:
     def __init__(self):
         self.domain = refresh_stre_domain()
         self.sc = API(self.domain)
+        self.sc.session.verify = False
         self.fixed_sc = FixedAPI(self.domain)
+        self.fixed_sc.session.verify = False
 
     def refresh(self):
         self.domain = refresh_stre_domain()
         self.sc = API(self.domain)
+        self.sc.session.verify = False
         self.fixed_sc = FixedAPI(self.domain)
+        self.fixed_sc.session.verify = False
 
 
 stre = StreAPI()

--- a/backend/utils/fixed_api.py
+++ b/backend/utils/fixed_api.py
@@ -131,6 +131,7 @@ class API:
         self.domain = domain
         self._url = urlparse("https://" + self.domain)
         self.session = requests.Session()
+        self.session.verify = False
 
     def _wbpage_as_text(self, url):
         try:


### PR DESCRIPTION
## Summary
- disable SSL certificate verification for `scuapi` and bundled API
- ensure fixed API session also bypasses certificate checks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a48d06c4c88333ab424e12a5fea2a8