### PR TITLE
Ignore SSL certificates for StreamingCommunity requests

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -31,12 +31,16 @@ class StreAPI:
     def __init__(self):
         self.domain = refresh_stre_domain()
         self.sc = API(self.domain)
+        self.sc.session.verify = False
         self.fixed_sc = FixedAPI(self.domain)
+        self.fixed_sc.session.verify = False
 
     def refresh(self):
         self.domain = refresh_stre_domain()
         self.sc = API(self.domain)
+        self.sc.session.verify = False
         self.fixed_sc = FixedAPI(self.domain)
+        self.fixed_sc.session.verify = False
 
 
 stre = StreAPI()

--- a/backend/utils/app_functions.py
+++ b/backend/utils/app_functions.py
@@ -68,18 +68,34 @@ def refresh_stre_domain():
     return stre_domain
 
 def search(sc, query):
+    try:
+        sc.session.verify = False
+    except AttributeError:
+        pass
     results = sc.search(query)
     return results
 
 def get_info(sc, slug):
+    try:
+        sc.session.verify = False
+    except AttributeError:
+        pass
     results = sc.preview(slug)
     return results
 
 def get_extended_info(sc, slug):
+    try:
+        sc.session.verify = False
+    except AttributeError:
+        pass
     results = sc.load(slug)
     return results
 
 def get_links(sc, content_id, episode_id=None):
+    try:
+        sc.session.verify = False
+    except AttributeError:
+        pass
     results = sc.get_links(content_id, episode_id)
     return results
 

--- a/backend/utils/download_sc_video.py
+++ b/backend/utils/download_sc_video.py
@@ -29,6 +29,7 @@ def download_sc_video(url, queue, cancel_event: threading.Event, output_path="do
         'noplaylist': True,
         'merge_output_format': 'mp4',
         'progress_hooks': [hook],
+        'nocheckcertificate': True,
     }
 
     with YoutubeDL(ydl_opts) as ydl:

--- a/backend/utils/fixed_api.py
+++ b/backend/utils/fixed_api.py
@@ -131,6 +131,7 @@ class API:
         self.domain = domain
         self._url = urlparse("https://" + self.domain)
         self.session = requests.Session()
+        self.session.verify = False
 
     def _wbpage_as_text(self, url):
         try:

--- a/backend/utils/get_available_domains.py
+++ b/backend/utils/get_available_domains.py
@@ -16,7 +16,7 @@ def get_available_domains():
     domains = []
 
     try:
-        response = requests.get(domains_url, timeout=10)
+        response = requests.get(domains_url, timeout=10, verify=False)
         response.raise_for_status()  # Raise an exception for bad status codes (4xx or 5xx)
         
         site_data = response.json()


### PR DESCRIPTION
## Summary
- disable certificate verification before all StreamingCommunity API calls
- skip SSL validation when retrieving available domains
- allow yt-dlp downloads without certificate checks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a48d06c4c88333ab424e12a5fea2a8