### PR TITLE
Allow configuring instance directory mapping in Docker

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,5 @@
 HOST_DOWNLOAD_DIR=
 # Imposta la porta host su cui esporre l'app Docker
 HOST_PORT=
+# Imposta la cartella host per la directory instance
+HOST_INSTANCE_DIR=

--- a/.env
+++ b/.env
@@ -3,4 +3,4 @@ HOST_DOWNLOAD_DIR=
 # Imposta la porta host su cui esporre l'app Docker
 HOST_PORT=
 # Imposta la cartella host per la directory instance
-HOST_INSTANCE_DIR=
+HOST_DB_DIR=

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ git clone https://github.com/riccardo-florio/stre-web-app.git
 cd stre-web-app
 ```
 
-Controllare se modificare il valore di `HOST_DOWNLOAD_DIR` e di `HOST_PORT` nel file `.env`.
+Controllare se modificare il valore di `HOST_DOWNLOAD_DIR`, `HOST_INSTANCE_DIR` e di `HOST_PORT` nel file `.env`.
 
 Quindi lanciare:
 
@@ -53,8 +53,9 @@ docker compose up --build -d
 Il servizio sarà raggiungibile su `http://localhost:5000` come nella modalità classica.
 
 Docker Compose carica automaticamente le variabili definite nel file `.env` presente nella repository.
-Imposta il valore di `HOST_DOWNLOAD_DIR` in questo file per scegliere dove salvare i file sul tuo computer.
-Se lasci la variabile vuota verrà utilizzato il percorso predefinito `./downloads`.
+Imposta i valori di `HOST_DOWNLOAD_DIR` e `HOST_INSTANCE_DIR` in questo file per scegliere dove salvare i file sul tuo computer e dove memorizzare la directory `instance`.
+Se lasci `HOST_DOWNLOAD_DIR` vuoto verrà utilizzato il percorso predefinito `./downloads`.
+Se lasci `HOST_INSTANCE_DIR` vuoto verrà utilizzato il percorso predefinito `./instance`.
 Puoi inoltre personalizzare la porta esposta all'host impostando `HOST_PORT`.
 Se non definita, la porta predefinita sarà `5000`.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ git clone https://github.com/riccardo-florio/stre-web-app.git
 cd stre-web-app
 ```
 
-Controllare se modificare il valore di `HOST_DOWNLOAD_DIR`, `HOST_INSTANCE_DIR` e di `HOST_PORT` nel file `.env`.
+Controllare se modificare il valore di `HOST_DOWNLOAD_DIR`, `HOST_DB_DIR` e di `HOST_PORT` nel file `.env`.
 
 Quindi lanciare:
 
@@ -53,9 +53,9 @@ docker compose up --build -d
 Il servizio sarà raggiungibile su `http://localhost:5000` come nella modalità classica.
 
 Docker Compose carica automaticamente le variabili definite nel file `.env` presente nella repository.
-Imposta i valori di `HOST_DOWNLOAD_DIR` e `HOST_INSTANCE_DIR` in questo file per scegliere dove salvare i file sul tuo computer e dove memorizzare la directory `instance`.
+Imposta i valori di `HOST_DOWNLOAD_DIR` e `HOST_DB_DIR` in questo file per scegliere dove salvare i file sul tuo computer e dove memorizzare la directory `instance`, che contiene il database.
 Se lasci `HOST_DOWNLOAD_DIR` vuoto verrà utilizzato il percorso predefinito `./downloads`.
-Se lasci `HOST_INSTANCE_DIR` vuoto verrà utilizzato il percorso predefinito `./instance`.
+Se lasci `HOST_DB_DIR` vuoto verrà utilizzato il percorso predefinito `./instance`.
 Puoi inoltre personalizzare la porta esposta all'host impostando `HOST_PORT`.
 Se non definita, la porta predefinita sarà `5000`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,4 @@ services:
       - "${HOST_PORT:-5000}:5000"
     volumes:
       - ${HOST_DOWNLOAD_DIR:-./downloads}:/app/downloads
+      - ${HOST_INSTANCE_DIR:-./instance}:/app/instance

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,4 @@ services:
       - "${HOST_PORT:-5000}:5000"
     volumes:
       - ${HOST_DOWNLOAD_DIR:-./downloads}:/app/downloads
-      - ${HOST_INSTANCE_DIR:-./instance}:/app/instance
+      - ${HOST_DB_DIR:-./instance}:/app/instance


### PR DESCRIPTION
## Summary
- add `HOST_INSTANCE_DIR` variable to `.env`
- map container `instance` folder to host via `HOST_INSTANCE_DIR` in `docker-compose.yml`
- document new variable and defaults in README

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8286439288333b133bfc7dfbac4d6