### PR TITLE
feat: track last watched content

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,6 @@ sessioni.
 
 ## TODO
 
-- aggiungere voce `updatedAt` alla tabella `video_progress` per tracciare effettivamente l'ultimo contenuto guardato
 - implementare eliminazione di tutti i video progress all'eliminazione di un utente
 
 - implementare cronologia (es. download completati, interrotti, ecc..)

--- a/backend/app.py
+++ b/backend/app.py
@@ -4,6 +4,7 @@ from flask_socketio import SocketIO, emit
 import json
 from pathlib import Path
 from uuid import uuid4
+from datetime import datetime
 from models import db, User, VideoProgress
 from sqlalchemy import text
 from utils.app_functions import (
@@ -68,6 +69,12 @@ def ensure_video_progress_columns():
     if "cover" not in columns:
         db.session.execute(
             text("ALTER TABLE video_progress ADD COLUMN cover VARCHAR(255)")
+        )
+    if "updated_at" not in columns:
+        db.session.execute(
+            text(
+                "ALTER TABLE video_progress ADD COLUMN updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
+            )
         )
     db.session.commit()
 
@@ -321,6 +328,7 @@ def video_progress(user_id, film_id):
                 "slug": entry.slug,
                 "title": entry.title,
                 "cover": entry.cover,
+                "updatedAt": entry.updated_at.isoformat() if entry.updated_at else None,
             }
         )
 
@@ -350,6 +358,7 @@ def video_progress(user_id, film_id):
             slug=slug,
             title=title,
             cover=cover,
+            updated_at=datetime.utcnow(),
         )
         db.session.add(entry)
     else:
@@ -362,6 +371,7 @@ def video_progress(user_id, film_id):
             entry.cover = cover
         if duration is not None:
             entry.duration = duration
+        entry.updated_at = datetime.utcnow()
     db.session.commit()
     return jsonify({"progress": entry.progress})
 
@@ -388,6 +398,7 @@ def all_progress():
                     "slug": vp.slug,
                     "title": vp.title,
                     "cover": vp.cover,
+                    "updatedAt": vp.updated_at.isoformat() if vp.updated_at else None,
                 }
                 for vp, username in entries
             ]
@@ -411,6 +422,7 @@ def user_progress(user_id):
                     "slug": e.slug,
                     "title": e.title,
                     "cover": e.cover,
+                    "updatedAt": e.updated_at.isoformat() if e.updated_at else None,
                 }
                 for e in entries
                 if e.progress > 0

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,5 +1,6 @@
 from flask_sqlalchemy import SQLAlchemy
 from werkzeug.security import generate_password_hash, check_password_hash
+from sqlalchemy import func
 
 # Initialize SQLAlchemy without app, will be bound in app factory
 
@@ -33,5 +34,11 @@ class VideoProgress(db.Model):
     slug = db.Column(db.String(255), nullable=True)
     title = db.Column(db.String(255), nullable=True)
     cover = db.Column(db.String(255), nullable=True)
+    updated_at = db.Column(
+        db.DateTime,
+        server_default=func.current_timestamp(),
+        onupdate=func.current_timestamp(),
+        nullable=False,
+    )
 
     __table_args__ = (db.UniqueConstraint('user_id', 'film_id', name='uniq_user_film'),)


### PR DESCRIPTION
## Summary
- add `updated_at` timestamp to `VideoProgress` model
- include `updatedAt` field in progress APIs and update on changes
- drop outdated TODO about timestamp from docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aac489c5c883338bef3da789763d22