### PR TITLE
Enable in-app updates from admin dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ Se lasci `HOST_DB_DIR` vuoto verrà utilizzato il percorso predefinito `./instan
 Puoi inoltre personalizzare la porta esposta all'host impostando `HOST_PORT`.
 Se non definita, la porta predefinita sarà `5000`.
 
+## Aggiornamento dell'app
+
+Dal pannello di amministrazione è possibile avviare l'aggiornamento dell'applicazione.
+Basta aprire la dashboard admin e premere il pulsante **Aggiorna**: verrà eseguito lo script `update.py`
+che recupera gli ultimi sorgenti dal repository, reinstalla le dipendenze e riavvia automaticamente il server.
+
 ## Come funziona
 
 Al lancio il backend recupera automaticamente il dominio valido di StreamingCommunity ed inizializza l'API:
@@ -178,5 +184,4 @@ sessioni.
 
 - implementare cronologia (es. download completati, interrotti, ecc..)
 - implementare tracciamento (es. chi scarica cosa, chi guarda cosa, ecc..)
-- implementare possibilità di aggiornare l'app dalla ui
 - aggiungere possibilità di usare custom url (non necessario al momento)

--- a/backend/app.py
+++ b/backend/app.py
@@ -5,6 +5,8 @@ import json
 from pathlib import Path
 from uuid import uuid4
 from datetime import datetime
+import subprocess
+import sys
 from models import db, User, VideoProgress
 from sqlalchemy import text
 from utils.app_functions import (
@@ -442,6 +444,18 @@ def export_db():
     if not db_path.exists():
         return jsonify({"error": "db not found"}), 404
     return send_file(db_path, as_attachment=True, download_name="users.db")
+
+
+@app.route("/api/update", methods=["POST"])
+def trigger_update():
+    """Execute the update script in background."""
+    if not is_admin_request():
+        return jsonify({"error": "forbidden"}), 403
+    script_path = BASE_DIR.parent / "update.py"
+    if not script_path.exists():
+        return jsonify({"error": "update script not found"}), 500
+    subprocess.Popen([sys.executable, str(script_path)])
+    return jsonify({"status": "updating"})
 
 @socketio.on("start_download")
 def handle_start_download(data):

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -282,6 +282,8 @@
                     onclick="showAdminSection('progress')">Video Progress</button>
                 <button id="admin-export-db" class="text-left px-2 py-1 rounded"
                     onclick="handleExportDb()">Esporta DB</button>
+                <button id="admin-update" class="text-left px-2 py-1 rounded"
+                    onclick="handleUpdate()">Aggiorna</button>
                 <button type="button" onclick="hideAdminModal()"
                     class="mt-auto text-left px-2 py-1 rounded text-red-600">Chiudi</button>
             </div>

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -156,6 +156,18 @@ async function exportDatabase() {
     return await res.blob();
 }
 
+async function triggerUpdate() {
+    const res = await fetch('/api/update', {
+        method: 'POST',
+        headers: { 'X-Role': localStorage.getItem('role') || '' }
+    });
+    const data = await res.json();
+    if (!res.ok) {
+        throw new Error(data.error || 'Errore nell\'aggiornamento');
+    }
+    return data;
+}
+
 
 async function fetchUser(id) {
     const res = await fetch(`/api/users/${id}`);

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -266,6 +266,15 @@ async function handleExportDb() {
     }
 }
 
+async function handleUpdate() {
+    try {
+        await triggerUpdate();
+        alert('Aggiornamento avviato, l\'app verrà riavviata.');
+    } catch (err) {
+        alert(err.message);
+    }
+}
+
 async function register(event) {
     event.preventDefault();
     const form = document.getElementById('registration-form');

--- a/update.py
+++ b/update.py
@@ -1,0 +1,35 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run(cmd):
+    """Run a command in the project root."""
+    subprocess.check_call(cmd, cwd=ROOT)
+
+
+ROOT = Path(__file__).resolve().parent
+
+
+def main():
+    # Check if repository is already up to date
+    status = subprocess.run(
+        ["git", "status", "-uno"], cwd=ROOT, capture_output=True, text=True
+    )
+    if "up to date" in status.stdout.lower():
+        print("Repository already up to date")
+        return
+
+    # Pull latest changes
+    run(["git", "pull", "origin", "main"])
+
+    # Reinstall requirements
+    run([sys.executable, "-m", "pip", "install", "-r", "requirements.txt"])
+
+    # Restart the application
+    subprocess.run(["pkill", "-f", "backend/app.py"], cwd=ROOT)
+    subprocess.Popen([sys.executable, "backend/app.py"], cwd=ROOT)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `update.py` script to pull latest code, reinstall dependencies and restart server
- expose `/api/update` endpoint and admin UI button to trigger updates
- document app update workflow

## Testing
- `python -m py_compile backend/app.py update.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab2a8dec6483338c47dcc59d4971ba