### PR TITLE
feat: add update section to admin dashboard

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2,6 +2,8 @@ from flask import Flask, send_from_directory, send_file, jsonify, Response, requ
 from asyncio import sleep
 from flask_socketio import SocketIO, emit
 import json
+import subprocess
+import sys
 from pathlib import Path
 from uuid import uuid4
 from datetime import datetime
@@ -132,6 +134,12 @@ def get_main_domain():
 @app.route("/api/get-app-version")
 def get_app_version():
     return jsonify(get_git_version())
+
+
+@app.route("/api/update-app", methods=["POST"])
+def update_app():
+    subprocess.Popen([sys.executable, "update.py"], cwd=BASE_DIR)
+    return jsonify({"status": "updating"}), 202
 
 @app.route("/api/refresh-domain", methods=["POST"])
 def refresh_domain():

--- a/backend/update.py
+++ b/backend/update.py
@@ -1,0 +1,14 @@
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+
+def main():
+    subprocess.run(["git", "pull"], cwd=ROOT_DIR, check=True)
+    subprocess.run([sys.executable, "-m", "pip", "install", "-r", "requirements.txt"], cwd=ROOT_DIR, check=True)
+    subprocess.run(["pkill", "-f", "app.py"], check=False)
+    subprocess.Popen([sys.executable, "app.py"], cwd=ROOT_DIR / "backend")
+
+if __name__ == "__main__":
+    main()

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -280,6 +280,8 @@
                     onclick="showAdminSection('users')">Utenti</button>
                 <button id="admin-progress-link" class="text-left px-2 py-1 rounded"
                     onclick="showAdminSection('progress')">Video Progress</button>
+                <button id="admin-update-link" class="text-left px-2 py-1 rounded"
+                    onclick="showAdminSection('update')">Aggiornamento</button>
                 <button id="admin-export-db" class="text-left px-2 py-1 rounded"
                     onclick="handleExportDb()">Esporta DB</button>
                 <button type="button" onclick="hideAdminModal()"
@@ -301,6 +303,14 @@
                             class="bg-gray-500 text-white px-3 py-1 rounded">Ricarica</button>
                     </div>
                     <div id="admin-progress" class="overflow-y-auto max-h-[70vh]"></div>
+                </div>
+                <div id="admin-update-section" class="w-full hidden">
+                    <div class="flex items-center justify-between mb-4">
+                        <h2 class="text-2xl">Aggiornamento</h2>
+                        <button type="button" onclick="populateUpdateSection()"
+                            class="bg-gray-500 text-white px-3 py-1 rounded">Ricarica</button>
+                    </div>
+                    <div id="admin-update" class="overflow-y-auto max-h-[70vh]"></div>
                 </div>
             </div>
         </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -320,6 +320,7 @@
         integrity="sha512-q/dWJ3kcmjBLU4Qc47E4A9kTB4m3wuTY7vkFJDTZKjTs8jhyGQnaUrxa0Ytd0ssMZhbNua9hE+E7Qv1j+DyZwA=="
         crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="js/api.js"></script>
     <script src="js/ui.js"></script>
     <script src="js/player.js"></script>

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -1,3 +1,6 @@
+const GITHUB_OWNER = 'riccardo-florio';
+const GITHUB_REPO = 'stre-web-app';
+
 async function fetchUrl() {
     const res = await fetch('/api/get-stre-domain');
     const data = await res.json();
@@ -24,6 +27,12 @@ async function fetchExtendedInfo(slug) {
 
 async function fetchAppVersion() {
     const res = await fetch('/api/get-app-version');
+    const data = await res.json();
+    return data;
+}
+
+async function fetchLatestRelease() {
+    const res = await fetch(`https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases/latest`);
     const data = await res.json();
     return data;
 }

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -37,6 +37,12 @@ async function fetchLatestRelease() {
     return data;
 }
 
+async function updateApp() {
+    const res = await fetch('/api/update-app', { method: 'POST' });
+    const data = await res.json();
+    return data;
+}
+
 async function fetchStreamingLinks(id, episodeId = null) {
     const url = episodeId
         ? `/api/get-streaming-links/${id}?episode_id=${episodeId}`

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -278,9 +278,29 @@ async function populateUpdateSection() {
                 <div class="mt-4 flex flex-col gap-2">${statusHtml}</div>
             </div>
         `;
+        const btn = document.getElementById('update-btn');
+        if (btn) {
+            btn.addEventListener('click', handleUpdateApp);
+        }
     } catch (err) {
         container.innerHTML = `<span class='text-red-600'>Errore nel recupero della release</span>`;
         console.error('Errore nel recupero della release', err);
+    }
+}
+
+async function handleUpdateApp() {
+    const btn = document.getElementById('update-btn');
+    if (btn) btn.disabled = true;
+    try {
+        await updateApp();
+        const status = document.getElementById('update-status');
+        if (status) {
+            status.textContent = 'Aggiornamento avviato...';
+            status.className = 'text-blue-600';
+        }
+    } catch (err) {
+        alert('Errore nell\'avvio dell\'aggiornamento');
+        if (btn) btn.disabled = false;
     }
 }
 

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -252,17 +252,30 @@ async function populateUpdateSection() {
     const container = document.getElementById('admin-update');
     container.innerHTML = '';
     try {
-        const release = await fetchLatestRelease();
+        const [release, currentVersion] = await Promise.all([
+            fetchLatestRelease(),
+            fetchAppVersion()
+        ]);
         const published = release.published_at
             ? new Date(release.published_at).toLocaleString()
             : '';
         const bodyHtml = release.body ? marked.parse(release.body) : '';
+        const latestVersion = release.tag_name || '';
+        let statusHtml = '';
+        if (currentVersion === latestVersion) {
+            statusHtml = `<span id="update-status" class="text-green-600">La versione installata (${currentVersion}) è la più recente.</span>`;
+        } else {
+            statusHtml = `<span id="update-status" class="text-red-600">Disponibile aggiornamento alla ${latestVersion} (installata ${currentVersion}).</span>
+                <button id="update-btn" class="bg-blue-500 text-white px-3 py-1 rounded mt-2">Aggiorna</button>`;
+        }
         container.innerHTML = `
             <div class="flex flex-col gap-2">
-                <span><strong>Versione:</strong> ${release.tag_name || ''}</span>
+                <span><strong>Ultima versione:</strong> ${latestVersion}</span>
+                <span><strong>Versione installata:</strong> ${currentVersion}</span>
                 <span><strong>Pubblicata:</strong> ${published}</span>
                 <a href="${release.html_url}" target="_blank" class="text-blue-600 underline">Vedi su GitHub</a>
                 <div class="text-pretty">${bodyHtml}</div>
+                <div class="mt-4 flex flex-col gap-2">${statusHtml}</div>
             </div>
         `;
     } catch (err) {

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -256,12 +256,13 @@ async function populateUpdateSection() {
         const published = release.published_at
             ? new Date(release.published_at).toLocaleString()
             : '';
+        const bodyHtml = release.body ? marked.parse(release.body) : '';
         container.innerHTML = `
             <div class="flex flex-col gap-2">
                 <span><strong>Versione:</strong> ${release.tag_name || ''}</span>
                 <span><strong>Pubblicata:</strong> ${published}</span>
                 <a href="${release.html_url}" target="_blank" class="text-blue-600 underline">Vedi su GitHub</a>
-                <p class="text-pretty whitespace-pre-line">${release.body || ''}</p>
+                <div class="text-pretty">${bodyHtml}</div>
             </div>
         `;
     } catch (err) {

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -95,13 +95,17 @@ function hideAdminModal() {
 function showAdminSection(section) {
     const usersLink = document.getElementById('admin-users-link');
     const progressLink = document.getElementById('admin-progress-link');
+    const updateLink = document.getElementById('admin-update-link');
     const usersSection = document.getElementById('admin-users-section');
     const progressSection = document.getElementById('admin-progress-section');
+    const updateSection = document.getElementById('admin-update-section');
 
     usersLink.classList.remove('bg-gray-200');
     progressLink.classList.remove('bg-gray-200');
+    updateLink.classList.remove('bg-gray-200');
     usersSection.classList.add('hidden');
     progressSection.classList.add('hidden');
+    updateSection.classList.add('hidden');
 
     if (section === 'users') {
         usersLink.classList.add('bg-gray-200');
@@ -111,6 +115,10 @@ function showAdminSection(section) {
         progressLink.classList.add('bg-gray-200');
         progressSection.classList.remove('hidden');
         populateProgressTable();
+    } else if (section === 'update') {
+        updateLink.classList.add('bg-gray-200');
+        updateSection.classList.remove('hidden');
+        populateUpdateSection();
     }
 }
 
@@ -237,6 +245,28 @@ async function populateProgressTable() {
         container.appendChild(table);
     } catch (err) {
         container.innerHTML = `<span class='text-red-600'>${err.message}</span>`;
+    }
+}
+
+async function populateUpdateSection() {
+    const container = document.getElementById('admin-update');
+    container.innerHTML = '';
+    try {
+        const release = await fetchLatestRelease();
+        const published = release.published_at
+            ? new Date(release.published_at).toLocaleString()
+            : '';
+        container.innerHTML = `
+            <div class="flex flex-col gap-2">
+                <span><strong>Versione:</strong> ${release.tag_name || ''}</span>
+                <span><strong>Pubblicata:</strong> ${published}</span>
+                <a href="${release.html_url}" target="_blank" class="text-blue-600 underline">Vedi su GitHub</a>
+                <p class="text-pretty whitespace-pre-line">${release.body || ''}</p>
+            </div>
+        `;
+    } catch (err) {
+        container.innerHTML = `<span class='text-red-600'>Errore nel recupero della release</span>`;
+        console.error('Errore nel recupero della release', err);
     }
 }
 


### PR DESCRIPTION
## Summary
- add Aggiornamento tab to admin dashboard
- fetch latest GitHub release info and display in dashboard

## Testing
- `python -m pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab338149cc8333b77dcce7e21aced6