### PR TITLE
Forward client IP for streaming links

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -164,7 +164,13 @@ def get_full_info(slug):
 @app.route("/api/get-streaming-links/<content_id>")
 def get_streaming_links(content_id):
     episode_id = request.args.get("episode_id")
-    results = get_links(stre.fixed_sc, content_id, episode_id)
+    forwarded_for = request.headers.get("X-Forwarded-For")
+    client_ip = (
+        forwarded_for.split(",")[0].strip() if forwarded_for else request.remote_addr
+    )
+    results = get_links(
+        stre.fixed_sc, content_id, episode_id, client_ip=client_ip
+    )
     return jsonify(results)
 
 

--- a/backend/utils/app_functions.py
+++ b/backend/utils/app_functions.py
@@ -79,8 +79,8 @@ def get_extended_info(sc, slug):
     results = sc.load(slug)
     return results
 
-def get_links(sc, content_id, episode_id=None):
-    results = sc.get_links(content_id, episode_id)
+def get_links(sc, content_id, episode_id=None, client_ip=None):
+    results = sc.get_links(content_id, episode_id, client_ip=client_ip)
     return results
 
 VERSION_FILE = ".version"


### PR DESCRIPTION
## Summary
- Capture client IP from requests and forward it through streaming link retrieval
- Allow get_links helpers to accept and propagate client IP
- Add X-Forwarded-For header support within fixed API requests

## Testing
- `python -m py_compile backend/app.py backend/utils/app_functions.py backend/utils/fixed_api.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac8000464083339e78873324dd8093