### PR TITLE
feat: retrieve streaming links directly from source

### DIFF
--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -242,8 +242,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     watchBtn.addEventListener('click', async () => {
         try {
-            const links = await fetchStreamingLinks(filmId);
-            const hlsLink = links.find(l => l.includes('playlist') || l.includes('.m3u8'));
+            const hlsLink = await fetchStreamingLinksDirect(filmId);
             if (hlsLink) {
                 showPlayer(hlsLink, filmId, filmSlug, filmTitle, filmCover);
             } else {

--- a/frontend/js/player.js
+++ b/frontend/js/player.js
@@ -222,8 +222,7 @@
         if (!nextEpisodeInfo) return;
         const { baseId, slug, nextEp } = nextEpisodeInfo;
         try {
-            const links = await fetchStreamingLinks(baseId, nextEp.id);
-            const hlsLink = links.find(l => l.includes('playlist') || l.includes('.m3u8'));
+            const hlsLink = await fetchStreamingLinksDirect(baseId, nextEp.id);
             if (!hlsLink) return;
             const epCover = (nextEp.images && nextEp.images.length)
                 ? `https://cdn.${mainUrl}/images/${nextEp.images[0].filename}`

--- a/frontend/js/ui.js
+++ b/frontend/js/ui.js
@@ -455,8 +455,7 @@ async function watchFromSearch(id, slug, title, cover, type) {
                 alert('Nessun episodio disponibile');
                 return;
             }
-            const links = await fetchStreamingLinks(id, firstEp.id);
-            hlsLink = links.find(l => l.includes('playlist') || l.includes('.m3u8'));
+            hlsLink = await fetchStreamingLinksDirect(id, firstEp.id);
             if (!hlsLink) {
                 alert('Nessun link disponibile');
                 return;
@@ -467,8 +466,7 @@ async function watchFromSearch(id, slug, title, cover, type) {
             finalId = `${id}-${firstEp.id}`;
             finalTitle = `${title} - S${firstEp.season}E${firstEp.episode} - ${firstEp.name}`;
         } else {
-            const links = await fetchStreamingLinks(id);
-            hlsLink = links.find(l => l.includes('playlist') || l.includes('.m3u8'));
+            hlsLink = await fetchStreamingLinksDirect(id);
             if (!hlsLink) {
                 alert('Nessun link disponibile');
                 return;
@@ -488,8 +486,7 @@ async function watchFromSearch(id, slug, title, cover, type) {
 async function resumeFromProgress(id, slug, title, cover) {
     try {
         const [baseId, episodeId] = id.split('-');
-        const links = await fetchStreamingLinks(baseId, episodeId || null);
-        const hlsLink = links.find(l => l.includes('playlist') || l.includes('.m3u8'));
+        const hlsLink = await fetchStreamingLinksDirect(baseId, episodeId || null);
         if (hlsLink) {
             filmId = id;
             filmTitle = title;
@@ -643,8 +640,7 @@ async function populateDownloadSection(slug, title) {
                 watchEpBtn.textContent = 'Guarda';
                 watchEpBtn.onclick = async () => {
                     try {
-                        const links = await fetchStreamingLinks(filmId, ep.id);
-                        const hlsLink = links.find(l => l.includes('playlist') || l.includes('.m3u8'));
+                        const hlsLink = await fetchStreamingLinksDirect(filmId, ep.id);
                         if (hlsLink) {
                             const epCover = (ep.images && ep.images.length)
                                 ? `https://cdn.${mainUrl}/images/${ep.images[0].filename}`


### PR DESCRIPTION
## Summary
- add `fetchStreamingLinksDirect` to scrape master playlist directly from the StreamingCommunity domain with CORS fallback
- replace backend `/api/get-streaming-links` usage with new direct function across the frontend

## Testing
- `node --check frontend/js/api.js`
- `node --check frontend/js/app.js`
- `node --check frontend/js/player.js`
- `node --check frontend/js/ui.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac8614d7a88333860b254cbbd82009